### PR TITLE
entry.cc: Don't call SimpleTokenizer's destructor explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ build/
 bin/
 output/
 output-no-jieba/
+
+# CLion
+.idea/
+cmake-build-debug/
+

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -20,7 +20,6 @@ int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, c
 
 void fts5_simple_xDelete(Fts5Tokenizer *p) {
   simple_tokenizer::SimpleTokenizer *pST = (simple_tokenizer::SimpleTokenizer *)p;
-  pST->~SimpleTokenizer();
   delete (pST);
 }
 


### PR DESCRIPTION
> `delete p` does two things: it calls the destructor and it deallocates the memory.

# Verification

```diff
diff --git a/src/simple_tokenizer.h b/src/simple_tokenizer.h
index 255d998..3e6b509 100644
--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -28,9 +28,14 @@ class SimpleTokenizer {
  private:
   static PinYin *get_pinyin();
   bool enable_pinyin = true;
+  int counter = 0;
 
  public:
   SimpleTokenizer(const char **zaArg, int nArg);
+  ~SimpleTokenizer() {
+    counter++;
+    printf("> Destructor call count: %d\n", counter);
+  }
   int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken);
   static std::string tokenize_query(const char *text, int textLen, int flags = 1);
 #ifdef USE_JIEBA

```

```bash
$ ./sqlite3
SQLite version 3.32.3 2020-06-18 14:00:33
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> .load ./libsimple
sqlite> CREATE VIRTUAL TABLE t1 USING fts5(text, tokenize = 'simple');
sqlite> INSERT INTO t1 VALUES ('中华人民共和国国歌');
sqlite> select simple_highlight(t1, 0, '[', ']') as text from t1 where text match simple_query('中华国歌');
[中华]人民共和[国国歌]
sqlite> 
> Destructor call count: 1
> Destructor call count: 2
```

As you can see, the destructor of `simple_tokenizer::SimpleTokenizer` was called twice, although you do not implement it.
For the sake of sanity, we must not call the destructor explicitly.

# After patch applied

```
sqlite> .load ./libsimple
sqlite> CREATE VIRTUAL TABLE t1 USING fts5(text, tokenize = 'simple');
sqlite> INSERT INTO t1 VALUES ('中华人民共和国国歌');
sqlite> select simple_highlight(t1, 0, '[', ']') as text from t1 where text match simple_query('中华国歌');
[中华]人民共和[国国歌]
sqlite> 
> Destructor call count: 1
```

# SEE ALSO

https://isocpp.org/wiki/faq/dtors#dont-call-dtor-on-obj-allocd-via-new
https://stackoverflow.com/questions/677653/does-delete-on-a-pointer-to-a-subclass-call-the-base-class-destructor