### PR TITLE
Various minor fixes

### DIFF
--- a/src/entry.cc
+++ b/src/entry.cc
@@ -100,7 +100,7 @@ static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal)
 int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
   (void)pzErrMsg;
   int rc = SQLITE_OK;
-  SQLITE_EXTENSION_INIT2(pApi);
+  SQLITE_EXTENSION_INIT2(pApi)
 
   rc = sqlite3_create_function(db, "simple_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &simple_query, NULL,
                                NULL);

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -6,10 +6,10 @@ SQLITE_EXTENSION_INIT1
 #include <new>
 
 int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut) {
-  int rc = SQLITE_OK;
+  (void) sqlite3;
   simple_tokenizer::SimpleTokenizer *p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
   *ppOut = reinterpret_cast<Fts5Tokenizer *>(p);
-  return rc;
+  return SQLITE_OK;
 }
 
 int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
@@ -45,7 +45,6 @@ static int fts5_api_from_db(sqlite3 *db, fts5_api **ppApi) {
 
 #ifdef USE_JIEBA
 static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  int rc;
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {
@@ -66,7 +65,6 @@ static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
 }
 
 static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  int rc;
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {
@@ -84,7 +82,6 @@ static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) 
 #endif
 
 static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  int rc;
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -98,6 +98,7 @@ static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal)
 }
 
 int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
+  (void)pzErrMsg;
   int rc = SQLITE_OK;
   SQLITE_EXTENSION_INIT2(pApi);
 

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -6,20 +6,20 @@ SQLITE_EXTENSION_INIT1
 #include <new>
 
 int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut) {
-  (void) sqlite3;
-  simple_tokenizer::SimpleTokenizer *p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
+  (void)sqlite3;
+  auto *p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
   *ppOut = reinterpret_cast<Fts5Tokenizer *>(p);
   return SQLITE_OK;
 }
 
 int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
                           xTokenFn xToken) {
-  simple_tokenizer::SimpleTokenizer *p = (simple_tokenizer::SimpleTokenizer *)tokenizer_ptr;
+  auto *p = (simple_tokenizer::SimpleTokenizer *)tokenizer_ptr;
   return p->tokenize(pCtx, flags, pText, nText, xToken);
 }
 
 void fts5_simple_xDelete(Fts5Tokenizer *p) {
-  simple_tokenizer::SimpleTokenizer *pST = (simple_tokenizer::SimpleTokenizer *)p;
+  auto *pST = (simple_tokenizer::SimpleTokenizer *)p;
   delete (pST);
 }
 
@@ -72,7 +72,7 @@ static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) 
       if (nVal >= 2) {
         flags = atoi((const char *)sqlite3_value_text(apVal[1]));
       }
-      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(text, std::strlen(text), flags);
+      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(text, (int)std::strlen(text), flags);
       sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
       return;
     }
@@ -89,7 +89,7 @@ static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal)
       if (nVal >= 2) {
         flags = atoi((const char *)sqlite3_value_text(apVal[1]));
       }
-      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_query(text, std::strlen(text), flags);
+      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_query(text, (int)std::strlen(text), flags);
       sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
       return;
     }

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -1,7 +1,6 @@
 #include "pinyin.h"
 
 #include <cmrc/cmrc.hpp>
-#include <iostream>
 #include <map>
 #include <regex>
 #include <set>

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -66,12 +66,9 @@ std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
   return pinyin;
 }
 
+// Get UTF8 character encoding length(via first byte)
 size_t PinYin::get_str_len(unsigned char byte) {
-  if (byte >= 0xFC)
-    return 6;
-  else if (byte >= 0xF8)
-    return 5;
-  else if (byte >= 0xF0)
+  if (byte >= 0xF0)
     return 4;
   else if (byte >= 0xE0)
     return 3;

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -66,7 +66,7 @@ std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
 }
 
 // Get UTF8 character encoding length(via first byte)
-size_t PinYin::get_str_len(unsigned char byte) {
+int PinYin::get_str_len(unsigned char byte) {
   if (byte >= 0xF0)
     return 4;
   else if (byte >= 0xE0)
@@ -78,7 +78,7 @@ size_t PinYin::get_str_len(unsigned char byte) {
 
 // get the first valid utf8 string's code point
 int PinYin::codepoint(const std::string &u) {
-  int l = u.length();
+  size_t l = u.length();
   if (l < 1) return -1;
   size_t len = get_str_len((unsigned char)u[0]);
   if (l < len) return -1;

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -5,6 +5,7 @@
 #include <regex>
 #include <set>
 #include <sstream>
+#include <stdexcept>
 #include <vector>
 
 CMRC_DECLARE(pinyin_text);
@@ -17,14 +18,14 @@ std::set<std::string> PinYin::to_plain(const std::string &input) {
   std::set<std::string> s;
   std::string value;
   for (size_t i = 0, len = 0; i != input.length(); i += len) {
-    unsigned char byte = (unsigned char)input[i];
+    auto byte = input[i];
     if (byte == ',') {
       s.insert(value);
       s.insert(value.substr(0, 1));
       value.clear();
       continue;
     }
-    len = get_str_len(byte);
+    len = get_str_len((unsigned char)byte);
     if (len == 1) {
       value.push_back(byte);
       continue;
@@ -43,7 +44,7 @@ std::set<std::string> PinYin::to_plain(const std::string &input) {
 
 // clang-format off
 std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
-  std::map<int, std::vector<std::string> > pinyin;
+  std::map<int, std::vector<std::string> > map;
   // clang-format on
   auto fs = cmrc::pinyin_text::get_filesystem();
   auto pinyin_data = fs.open("contrib/pinyin.txt");
@@ -60,9 +61,9 @@ std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
     std::set<std::string> s = to_plain(py);
     std::vector<std::string> m(s.size());
     std::copy(s.begin(), s.end(), m.begin());
-    pinyin[codepoint] = m;
+    map[codepoint] = m;
   }
-  return pinyin;
+  return map;
 }
 
 // Get UTF8 character encoding length(via first byte)
@@ -93,7 +94,7 @@ int PinYin::codepoint(const std::string &u) {
       return ((unsigned char)u[0] - 240) * 262144 + ((unsigned char)u[1] - 128) * 4096 +
              ((unsigned char)u[2] - 128) * 64 + ((unsigned char)u[3] - 128);
     default:
-      return -1;
+      throw std::runtime_error("should never happen");
   }
 }
 
@@ -119,7 +120,7 @@ std::vector<std::string> PinYin::_split_pinyin(const std::string &input, int beg
       continue;
     }
     std::vector<std::string> tmp = _split_pinyin(input, start, end);
-    for (auto s : tmp) {
+    for (const auto &s : tmp) {
       result.push_back(first + "+" + s);
     }
     ++start;
@@ -128,7 +129,7 @@ std::vector<std::string> PinYin::_split_pinyin(const std::string &input, int beg
 }
 
 std::set<std::string> PinYin::split_pinyin(const std::string &input) {
-  int slen = input.size();
+  int slen = (int)input.size();
   const int max_length = 20;
   if (slen > max_length || slen <= 1) {
     return {input};

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -112,7 +112,7 @@ class PinYin {
 
  public:
   const std::vector<std::string> &get_pinyin(const std::string &chinese);
-  static size_t get_str_len(unsigned char byte);
+  static int get_str_len(unsigned char byte);
   std::set<std::string> split_pinyin(const std::string &input);
   PinYin();
 };

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -107,12 +107,12 @@ class PinYin {
   // clang-format on
   std::set<std::string> to_plain(const std::string &input);
   std::map<int, std::vector<std::string> > build_pinyin_map();
-  int codepoint(const std::string &u);
+  static int codepoint(const std::string &u);
   std::vector<std::string> _split_pinyin(const std::string &input, int begin, int end);
 
  public:
   const std::vector<std::string> &get_pinyin(const std::string &chinese);
-  size_t get_str_len(unsigned char byte);
+  static size_t get_str_len(unsigned char byte);
   std::set<std::string> split_pinyin(const std::string &input);
   PinYin();
 };

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -20,20 +20,6 @@ PinYin *SimpleTokenizer::get_pinyin() {
   return py;
 }
 
-class Token {
- public:
-  int start;
-  int end;
-  TokenCategory category;
-
- public:
-  Token(int s, int e, TokenCategory c) : start(s), end(e), category(c) {}
-};
-
-std::ostream &operator<<(std::ostream &os, Token const &t) {
-  return os << t.start << " " << t.end << " " << static_cast<int>(t.category);
-}
-
 static TokenCategory from_char(char c) {
   if (std::isdigit(c)) {
     return TokenCategory::DIGIT;

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -61,6 +61,7 @@ std::string SimpleTokenizer::tokenize_query(const char *text, int textLen, int f
 #ifdef USE_JIEBA
 std::string jieba_dict_path = "./dict/";
 std::string SimpleTokenizer::tokenize_jieba_query(const char *text, int textLen, int flags) {
+  (void)textLen;
   static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8", jieba_dict_path + "hmm_model.utf8",
                                jieba_dict_path + "user.dict.utf8", jieba_dict_path + "idf.utf8",
                                jieba_dict_path + "stop_words.utf8");

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -42,7 +42,7 @@ std::string SimpleTokenizer::tokenize_query(const char *text, int textLen, int f
     TokenCategory category = from_char(text[index]);
     switch (category) {
       case TokenCategory::OTHER:
-        index += SimpleTokenizer::get_pinyin()->get_str_len(text[index]);
+        index += PinYin::get_str_len(text[index]);
         break;
       default:
         while (++index < textLen && from_char(text[index]) == category) {
@@ -129,7 +129,7 @@ int SimpleTokenizer::tokenize(void *pCtx, int flags, const char *text, int textL
     TokenCategory category = from_char(text[index]);
     switch (category) {
       case TokenCategory::OTHER:
-        index += SimpleTokenizer::get_pinyin()->get_str_len(text[index]);
+        index += PinYin::get_str_len(text[index]);
         break;
       default:
         while (++index < textLen && from_char(text[index]) == category) {

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -31,7 +31,7 @@ class SimpleTokenizer {
 
  public:
   SimpleTokenizer(const char **zaArg, int nArg);
-  int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken);
+  int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const;
   static std::string tokenize_query(const char *text, int textLen, int flags = 1);
 #ifdef USE_JIEBA
   static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1);


### PR DESCRIPTION
The outstanding commit should be the https://github.com/wangfenjin/simple/commit/7dfd173bb59c81841dccdc13da78cee7a51ab12a

According to https://en.wikipedia.org/wiki/UTF-8#Encoding and https://en.wikipedia.org/wiki/UTF-8#FSS-UTF
What you're previously using is an outdated UTF-8 standard(i.e. UTF-8 (1993))

> UTF-8 was first officially presented at the USENIX conference in San Diego, from January 25 to 29, 1993. The Internet Engineering Task Force adopted UTF-8 in its Policy on Character Sets and Languages in RFC 2277 (BCP 18) for future Internet standards work, replacing Single Byte Character Sets such as Latin-1 in older RFCs.[52]
>
> In November 2003, UTF-8 was restricted by [RFC 3629](https://datatracker.ietf.org/doc/html/rfc3629#page-4) to **match** the constraints of the UTF-16 character encoding: **explicitly prohibiting code points corresponding to the high and low surrogate characters removed more than 3% of the three-byte sequences, and ending at U+10FFFF removed more than 48% of the four-byte sequences and all five- and six-byte sequences**.

Another thing that might be worth mention is that `entry.cc` use `0` and `NULL` a lot, which their nullability semantics is yet not compatible with `nullptr` in C++.
(P.S. I'm not replacing `NULL` with `nullptr` in this PR, this might be necessary)
see: https://changkun.de/modern-cpp/zh-cn/02-usability/index.html#nullptr