### PR TITLE
Add query method to handle all tokenize logic

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 BasedOnStyle: Chromium
-ColumnLimit: 80
+ColumnLimit: 120
 BreakBeforeBraces: Attach
 IndentWidth: 4
 BreakConstructorInitializers: BeforeComma

--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,9 @@
-# Use the Google style in this project.
-BasedOnStyle: Google
-
-ColumnLimit: 120
+BasedOnStyle: Chromium
+ColumnLimit: 80
+BreakBeforeBraces: Attach
+IndentWidth: 4
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+AccessModifierOffset: -4
+AllowShortLambdasOnASingleLine: Empty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ if (MSVC)
    # https://stackoverflow.com/a/65128497/1203241
    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
    set(BUILD_SHARED_LIBS TRUE)
+   add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 endif()
 
 set(SQLITE3_HEADERS_DIR ${PROJECT_SOURCE_DIR}/contrib/sqlite3)

--- a/cpplint.cfg
+++ b/cpplint.cfg
@@ -1,0 +1,3 @@
+set noparent
+linelength=80
+filter=-whitespace/indent,-build/include_subdir,-runtime/references

--- a/cpplint.cfg
+++ b/cpplint.cfg
@@ -1,3 +1,0 @@
-set noparent
-linelength=80
-filter=-whitespace/indent,-build/include_subdir,-runtime/references

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -1,26 +1,33 @@
-#include "simple_highlight.h"
-#include "simple_tokenizer.h"
-#include "simple_def.h"
-SQLITE_EXTENSION_INIT1
 #include <cstring>
 #include <new>
+#include "simple_def.h"
+#include "simple_highlight.h"
+#include "simple_tokenizer.h"
+SQLITE_EXTENSION_INIT1
 
-int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut) {
-  (void)sqlite3;
-  auto *p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
-  *ppOut = reinterpret_cast<Fts5Tokenizer *>(p);
-  return SQLITE_OK;
+int fts5_simple_xCreate(void* sqlite3,
+                        const char** azArg,
+                        int nArg,
+                        Fts5Tokenizer** ppOut) {
+    (void)sqlite3;
+    auto* p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
+    *ppOut = reinterpret_cast<Fts5Tokenizer*>(p);
+    return SQLITE_OK;
 }
 
-int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
+int fts5_simple_xTokenize(Fts5Tokenizer* tokenizer_ptr,
+                          void* pCtx,
+                          int flags,
+                          const char* pText,
+                          int nText,
                           xTokenFn xToken) {
-  auto *p = (simple_tokenizer::SimpleTokenizer *)tokenizer_ptr;
-  return p->tokenize(pCtx, flags, pText, nText, xToken);
+    auto* p = (simple_tokenizer::SimpleTokenizer*)tokenizer_ptr;
+    return p->tokenize(pCtx, flags, pText, nText, xToken);
 }
 
-void fts5_simple_xDelete(Fts5Tokenizer *p) {
-  auto *pST = (simple_tokenizer::SimpleTokenizer *)p;
-  delete (pST);
+void fts5_simple_xDelete(Fts5Tokenizer* p) {
+    auto* pST = (simple_tokenizer::SimpleTokenizer*)p;
+    delete (pST);
 }
 
 /*
@@ -28,40 +35,41 @@ void fts5_simple_xDelete(Fts5Tokenizer *p) {
 ** If an error occurs, return NULL and leave an error in the database
 ** handle (accessible using sqlite3_errcode()/errmsg()).
 */
-static int fts5_api_from_db(sqlite3 *db, fts5_api **ppApi) {
-  sqlite3_stmt *pStmt = 0;
-  int rc;
+static int fts5_api_from_db(sqlite3* db, fts5_api** ppApi) {
+    sqlite3_stmt* pStmt = 0;
+    int rc;
 
-  *ppApi = 0;
-  rc = sqlite3_prepare(db, "SELECT fts5(?1)", -1, &pStmt, 0);
-  if (rc == SQLITE_OK) {
-    sqlite3_bind_pointer(pStmt, 1, reinterpret_cast<void *>(ppApi), "fts5_api_ptr", 0);
-    (void)sqlite3_step(pStmt);
-    rc = sqlite3_finalize(pStmt);
-  }
+    *ppApi = 0;
+    rc = sqlite3_prepare(db, "SELECT fts5(?1)", -1, &pStmt, 0);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_pointer(pStmt, 1, reinterpret_cast<void*>(ppApi),
+                             "fts5_api_ptr", 0);
+        (void)sqlite3_step(pStmt);
+        rc = sqlite3_finalize(pStmt);
+    }
 
-  return rc;
+    return rc;
 }
 
 #ifdef USE_JIEBA
-static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  if (nVal >= 1) {
-    const char *text = (const char *)sqlite3_value_text(apVal[0]);
-    if (text) {
-      std::string tmp(text);
-      char sep = '/';
+static void jieba_dict(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
+    if (nVal >= 1) {
+        const char* text = (const char*)sqlite3_value_text(apVal[0]);
+        if (text) {
+            std::string tmp(text);
+            char sep = '/';
 #ifdef _WIN32
-      sep = '\\';
+            sep = '\\';
 #endif
-      if (tmp.back() != sep) {  // Need to add a
-        tmp += sep;             // path separator
-      }
-      simple_tokenizer::jieba_dict_path = tmp;
-      sqlite3_result_text(pCtx, tmp.c_str(), -1, SQLITE_TRANSIENT);
-      return;
+            if (tmp.back() != sep) {  // Need to add a
+                tmp += sep;           // path separator
+            }
+            simple_tokenizer::jieba_dict_path = tmp;
+            sqlite3_result_text(pCtx, tmp.c_str(), -1, SQLITE_TRANSIENT);
+            return;
+        }
     }
-  }
-  sqlite3_result_null(pCtx);
+    sqlite3_result_null(pCtx);
 }
 
 static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
@@ -112,65 +120,87 @@ static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
     sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
 }
 
-static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  if (nVal >= 1) {
-    const char *text = (const char *)sqlite3_value_text(apVal[0]);
-    if (text) {
-      int flags = 1;
-      if (nVal >= 2) {
-        flags = atoi((const char *)sqlite3_value_text(apVal[1]));
-      }
-      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(text, (int)std::strlen(text), flags);
-      sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
-      return;
+static void jieba_query(sqlite3_context* pCtx,
+                        int nVal,
+                        sqlite3_value** apVal) {
+    if (nVal >= 1) {
+        const char* text = (const char*)sqlite3_value_text(apVal[0]);
+        if (text) {
+            int flags = 1;
+            if (nVal >= 2) {
+                flags = atoi((const char*)sqlite3_value_text(apVal[1]));
+            }
+            std::string result =
+                simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(
+                    text, (int)std::strlen(text), flags);
+            sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
+            return;
+        }
     }
-  }
-  sqlite3_result_null(pCtx);
+    sqlite3_result_null(pCtx);
 }
 #endif
 
-static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  if (nVal >= 1) {
-    const char *text = (const char *)sqlite3_value_text(apVal[0]);
-    if (text) {
-      int flags = 1;
-      if (nVal >= 2) {
-        flags = atoi((const char *)sqlite3_value_text(apVal[1]));
-      }
-      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_query(text, (int)std::strlen(text), flags);
-      sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
-      return;
+static void simple_query(sqlite3_context* pCtx,
+                         int nVal,
+                         sqlite3_value** apVal) {
+    if (nVal >= 1) {
+        const char* text = (const char*)sqlite3_value_text(apVal[0]);
+        if (text) {
+            int flags = 1;
+            if (nVal >= 2) {
+                flags = atoi((const char*)sqlite3_value_text(apVal[1]));
+            }
+            std::string result =
+                simple_tokenizer::SimpleTokenizer::tokenize_query(
+                    text, (int)std::strlen(text), flags);
+            sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
+            return;
+        }
     }
-  }
-  sqlite3_result_null(pCtx);
+    sqlite3_result_null(pCtx);
 }
 
-int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
-  (void)pzErrMsg;
-  int rc = SQLITE_OK;
-  SQLITE_EXTENSION_INIT2(pApi)
+int sqlite3_simple_init(sqlite3* db,
+                        char** pzErrMsg,
+                        const sqlite3_api_routines* pApi) {
+    (void)pzErrMsg;
+    int rc = SQLITE_OK;
+    SQLITE_EXTENSION_INIT2(pApi)
 
-  rc = sqlite3_create_function(db, "simple_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &simple_query, NULL,
-                               NULL);
+    rc = sqlite3_create_function(db, "simple_query", -1,
+                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
+                                 &simple_query, NULL, NULL);
 #ifdef USE_JIEBA
-  rc = sqlite3_create_function(db, "jieba_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_query, NULL,
-                               NULL);
-  rc = sqlite3_create_function(db, "jieba_dict", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_dict, NULL, NULL);
+    rc = sqlite3_create_function(db, "jieba_query", -1,
+                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
+                                 &jieba_query, NULL, NULL);
+    rc = sqlite3_create_function(db, "jieba_dict", 1,
+                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
+                                 &jieba_dict, NULL, NULL);
 #endif
 
-  // fts5_tokenizer tokenizer = {fts5AsciiCreate, fts5AsciiDelete, fts5AsciiTokenize };
-  fts5_tokenizer tokenizer = {fts5_simple_xCreate, fts5_simple_xDelete, fts5_simple_xTokenize};
-  fts5_api *fts5api;
-  rc = fts5_api_from_db(db, &fts5api);
-  if (rc != SQLITE_OK) return rc;
-  if (fts5api == 0 || fts5api->iVersion < 2) {
-    return SQLITE_ERROR;
-  }
-  rc = fts5api->xCreateTokenizer(fts5api, "simple", reinterpret_cast<void *>(fts5api), &tokenizer, NULL);
-  rc =
-      fts5api->xCreateFunction(fts5api, "simple_highlight", reinterpret_cast<void *>(fts5api), &simple_highlight, NULL);
-  rc = fts5api->xCreateFunction(fts5api, "simple_highlight_pos", reinterpret_cast<void *>(fts5api),
-                                &simple_highlight_pos, NULL);
-  rc = fts5api->xCreateFunction(fts5api, "simple_snippet", reinterpret_cast<void *>(fts5api), &simple_snippet, NULL);
-  return rc;
+    // fts5_tokenizer tokenizer = {fts5AsciiCreate, fts5AsciiDelete,
+    // fts5AsciiTokenize };
+    fts5_tokenizer tokenizer = {fts5_simple_xCreate, fts5_simple_xDelete,
+                                fts5_simple_xTokenize};
+    fts5_api* fts5api;
+    rc = fts5_api_from_db(db, &fts5api);
+    if (rc != SQLITE_OK)
+        return rc;
+    if (fts5api == 0 || fts5api->iVersion < 2) {
+        return SQLITE_ERROR;
+    }
+    rc = fts5api->xCreateTokenizer(
+        fts5api, "simple", reinterpret_cast<void*>(fts5api), &tokenizer, NULL);
+    rc = fts5api->xCreateFunction(fts5api, "simple_highlight",
+                                  reinterpret_cast<void*>(fts5api),
+                                  &simple_highlight, NULL);
+    rc = fts5api->xCreateFunction(fts5api, "simple_highlight_pos",
+                                  reinterpret_cast<void*>(fts5api),
+                                  &simple_highlight_pos, NULL);
+    rc = fts5api->xCreateFunction(fts5api, "simple_snippet",
+                                  reinterpret_cast<void*>(fts5api),
+                                  &simple_snippet, NULL);
+    return rc;
 }

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -1,33 +1,26 @@
-#include <cstring>
-#include <new>
-#include "simple_def.h"
 #include "simple_highlight.h"
 #include "simple_tokenizer.h"
+#include "simple_def.h"
 SQLITE_EXTENSION_INIT1
+#include <cstring>
+#include <new>
 
-int fts5_simple_xCreate(void* sqlite3,
-                        const char** azArg,
-                        int nArg,
-                        Fts5Tokenizer** ppOut) {
-    (void)sqlite3;
-    auto* p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
-    *ppOut = reinterpret_cast<Fts5Tokenizer*>(p);
-    return SQLITE_OK;
+int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut) {
+  (void)sqlite3;
+  auto *p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
+  *ppOut = reinterpret_cast<Fts5Tokenizer *>(p);
+  return SQLITE_OK;
 }
 
-int fts5_simple_xTokenize(Fts5Tokenizer* tokenizer_ptr,
-                          void* pCtx,
-                          int flags,
-                          const char* pText,
-                          int nText,
+int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
                           xTokenFn xToken) {
-    auto* p = (simple_tokenizer::SimpleTokenizer*)tokenizer_ptr;
-    return p->tokenize(pCtx, flags, pText, nText, xToken);
+  auto *p = (simple_tokenizer::SimpleTokenizer *)tokenizer_ptr;
+  return p->tokenize(pCtx, flags, pText, nText, xToken);
 }
 
-void fts5_simple_xDelete(Fts5Tokenizer* p) {
-    auto* pST = (simple_tokenizer::SimpleTokenizer*)p;
-    delete (pST);
+void fts5_simple_xDelete(Fts5Tokenizer *p) {
+  auto *pST = (simple_tokenizer::SimpleTokenizer *)p;
+  delete (pST);
 }
 
 /*
@@ -35,41 +28,40 @@ void fts5_simple_xDelete(Fts5Tokenizer* p) {
 ** If an error occurs, return NULL and leave an error in the database
 ** handle (accessible using sqlite3_errcode()/errmsg()).
 */
-static int fts5_api_from_db(sqlite3* db, fts5_api** ppApi) {
-    sqlite3_stmt* pStmt = 0;
-    int rc;
+static int fts5_api_from_db(sqlite3 *db, fts5_api **ppApi) {
+  sqlite3_stmt *pStmt = 0;
+  int rc;
 
-    *ppApi = 0;
-    rc = sqlite3_prepare(db, "SELECT fts5(?1)", -1, &pStmt, 0);
-    if (rc == SQLITE_OK) {
-        sqlite3_bind_pointer(pStmt, 1, reinterpret_cast<void*>(ppApi),
-                             "fts5_api_ptr", 0);
-        (void)sqlite3_step(pStmt);
-        rc = sqlite3_finalize(pStmt);
-    }
+  *ppApi = 0;
+  rc = sqlite3_prepare(db, "SELECT fts5(?1)", -1, &pStmt, 0);
+  if (rc == SQLITE_OK) {
+    sqlite3_bind_pointer(pStmt, 1, reinterpret_cast<void *>(ppApi), "fts5_api_ptr", 0);
+    (void)sqlite3_step(pStmt);
+    rc = sqlite3_finalize(pStmt);
+  }
 
-    return rc;
+  return rc;
 }
 
 #ifdef USE_JIEBA
-static void jieba_dict(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
-    if (nVal >= 1) {
-        const char* text = (const char*)sqlite3_value_text(apVal[0]);
-        if (text) {
-            std::string tmp(text);
-            char sep = '/';
+static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+  if (nVal >= 1) {
+    const char *text = (const char *)sqlite3_value_text(apVal[0]);
+    if (text) {
+      std::string tmp(text);
+      char sep = '/';
 #ifdef _WIN32
-            sep = '\\';
+      sep = '\\';
 #endif
-            if (tmp.back() != sep) {  // Need to add a
-                tmp += sep;           // path separator
-            }
-            simple_tokenizer::jieba_dict_path = tmp;
-            sqlite3_result_text(pCtx, tmp.c_str(), -1, SQLITE_TRANSIENT);
-            return;
-        }
+      if (tmp.back() != sep) {  // Need to add a
+        tmp += sep;             // path separator
+      }
+      simple_tokenizer::jieba_dict_path = tmp;
+      sqlite3_result_text(pCtx, tmp.c_str(), -1, SQLITE_TRANSIENT);
+      return;
     }
-    sqlite3_result_null(pCtx);
+  }
+  sqlite3_result_null(pCtx);
 }
 
 static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
@@ -120,87 +112,65 @@ static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
     sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
 }
 
-static void jieba_query(sqlite3_context* pCtx,
-                        int nVal,
-                        sqlite3_value** apVal) {
-    if (nVal >= 1) {
-        const char* text = (const char*)sqlite3_value_text(apVal[0]);
-        if (text) {
-            int flags = 1;
-            if (nVal >= 2) {
-                flags = atoi((const char*)sqlite3_value_text(apVal[1]));
-            }
-            std::string result =
-                simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(
-                    text, (int)std::strlen(text), flags);
-            sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
-            return;
-        }
+static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+  if (nVal >= 1) {
+    const char *text = (const char *)sqlite3_value_text(apVal[0]);
+    if (text) {
+      int flags = 1;
+      if (nVal >= 2) {
+        flags = atoi((const char *)sqlite3_value_text(apVal[1]));
+      }
+      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(text, (int)std::strlen(text), flags);
+      sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
+      return;
     }
-    sqlite3_result_null(pCtx);
+  }
+  sqlite3_result_null(pCtx);
 }
 #endif
 
-static void simple_query(sqlite3_context* pCtx,
-                         int nVal,
-                         sqlite3_value** apVal) {
-    if (nVal >= 1) {
-        const char* text = (const char*)sqlite3_value_text(apVal[0]);
-        if (text) {
-            int flags = 1;
-            if (nVal >= 2) {
-                flags = atoi((const char*)sqlite3_value_text(apVal[1]));
-            }
-            std::string result =
-                simple_tokenizer::SimpleTokenizer::tokenize_query(
-                    text, (int)std::strlen(text), flags);
-            sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
-            return;
-        }
+static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+  if (nVal >= 1) {
+    const char *text = (const char *)sqlite3_value_text(apVal[0]);
+    if (text) {
+      int flags = 1;
+      if (nVal >= 2) {
+        flags = atoi((const char *)sqlite3_value_text(apVal[1]));
+      }
+      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_query(text, (int)std::strlen(text), flags);
+      sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
+      return;
     }
-    sqlite3_result_null(pCtx);
+  }
+  sqlite3_result_null(pCtx);
 }
 
-int sqlite3_simple_init(sqlite3* db,
-                        char** pzErrMsg,
-                        const sqlite3_api_routines* pApi) {
-    (void)pzErrMsg;
-    int rc = SQLITE_OK;
-    SQLITE_EXTENSION_INIT2(pApi)
+int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
+  (void)pzErrMsg;
+  int rc = SQLITE_OK;
+  SQLITE_EXTENSION_INIT2(pApi)
 
-    rc = sqlite3_create_function(db, "simple_query", -1,
-                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
-                                 &simple_query, NULL, NULL);
+  rc = sqlite3_create_function(db, "simple_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &simple_query, NULL,
+                               NULL);
 #ifdef USE_JIEBA
-    rc = sqlite3_create_function(db, "jieba_query", -1,
-                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
-                                 &jieba_query, NULL, NULL);
-    rc = sqlite3_create_function(db, "jieba_dict", 1,
-                                 SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL,
-                                 &jieba_dict, NULL, NULL);
+  rc = sqlite3_create_function(db, "jieba_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_query, NULL,
+                               NULL);
+  rc = sqlite3_create_function(db, "jieba_dict", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_dict, NULL, NULL);
 #endif
 
-    // fts5_tokenizer tokenizer = {fts5AsciiCreate, fts5AsciiDelete,
-    // fts5AsciiTokenize };
-    fts5_tokenizer tokenizer = {fts5_simple_xCreate, fts5_simple_xDelete,
-                                fts5_simple_xTokenize};
-    fts5_api* fts5api;
-    rc = fts5_api_from_db(db, &fts5api);
-    if (rc != SQLITE_OK)
-        return rc;
-    if (fts5api == 0 || fts5api->iVersion < 2) {
-        return SQLITE_ERROR;
-    }
-    rc = fts5api->xCreateTokenizer(
-        fts5api, "simple", reinterpret_cast<void*>(fts5api), &tokenizer, NULL);
-    rc = fts5api->xCreateFunction(fts5api, "simple_highlight",
-                                  reinterpret_cast<void*>(fts5api),
-                                  &simple_highlight, NULL);
-    rc = fts5api->xCreateFunction(fts5api, "simple_highlight_pos",
-                                  reinterpret_cast<void*>(fts5api),
-                                  &simple_highlight_pos, NULL);
-    rc = fts5api->xCreateFunction(fts5api, "simple_snippet",
-                                  reinterpret_cast<void*>(fts5api),
-                                  &simple_snippet, NULL);
-    return rc;
+  // fts5_tokenizer tokenizer = {fts5AsciiCreate, fts5AsciiDelete, fts5AsciiTokenize };
+  fts5_tokenizer tokenizer = {fts5_simple_xCreate, fts5_simple_xDelete, fts5_simple_xTokenize};
+  fts5_api *fts5api;
+  rc = fts5_api_from_db(db, &fts5api);
+  if (rc != SQLITE_OK) return rc;
+  if (fts5api == 0 || fts5api->iVersion < 2) {
+    return SQLITE_ERROR;
+  }
+  rc = fts5api->xCreateTokenizer(fts5api, "simple", reinterpret_cast<void *>(fts5api), &tokenizer, NULL);
+  rc =
+      fts5api->xCreateFunction(fts5api, "simple_highlight", reinterpret_cast<void *>(fts5api), &simple_highlight, NULL);
+  rc = fts5api->xCreateFunction(fts5api, "simple_highlight_pos", reinterpret_cast<void *>(fts5api),
+                                &simple_highlight_pos, NULL);
+  rc = fts5api->xCreateFunction(fts5api, "simple_snippet", reinterpret_cast<void *>(fts5api), &simple_snippet, NULL);
+  return rc;
 }

--- a/src/entry.cc
+++ b/src/entry.cc
@@ -1,26 +1,30 @@
+#include "simple_def.h"
 #include "simple_highlight.h"
 #include "simple_tokenizer.h"
-#include "simple_def.h"
 SQLITE_EXTENSION_INIT1
 #include <cstring>
 #include <new>
 
-int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut) {
-  (void)sqlite3;
-  auto *p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
-  *ppOut = reinterpret_cast<Fts5Tokenizer *>(p);
-  return SQLITE_OK;
+int fts5_simple_xCreate(void* sqlite3, const char** azArg, int nArg, Fts5Tokenizer** ppOut) {
+    (void)sqlite3;
+    auto* p = new simple_tokenizer::SimpleTokenizer(azArg, nArg);
+    *ppOut = reinterpret_cast<Fts5Tokenizer*>(p);
+    return SQLITE_OK;
 }
 
-int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
+int fts5_simple_xTokenize(Fts5Tokenizer* tokenizer_ptr,
+                          void* pCtx,
+                          int flags,
+                          const char* pText,
+                          int nText,
                           xTokenFn xToken) {
-  auto *p = (simple_tokenizer::SimpleTokenizer *)tokenizer_ptr;
-  return p->tokenize(pCtx, flags, pText, nText, xToken);
+    auto* p = (simple_tokenizer::SimpleTokenizer*)tokenizer_ptr;
+    return p->tokenize(pCtx, flags, pText, nText, xToken);
 }
 
-void fts5_simple_xDelete(Fts5Tokenizer *p) {
-  auto *pST = (simple_tokenizer::SimpleTokenizer *)p;
-  delete (pST);
+void fts5_simple_xDelete(Fts5Tokenizer* p) {
+    auto* pST = (simple_tokenizer::SimpleTokenizer*)p;
+    delete (pST);
 }
 
 /*
@@ -28,40 +32,40 @@ void fts5_simple_xDelete(Fts5Tokenizer *p) {
 ** If an error occurs, return NULL and leave an error in the database
 ** handle (accessible using sqlite3_errcode()/errmsg()).
 */
-static int fts5_api_from_db(sqlite3 *db, fts5_api **ppApi) {
-  sqlite3_stmt *pStmt = 0;
-  int rc;
+static int fts5_api_from_db(sqlite3* db, fts5_api** ppApi) {
+    sqlite3_stmt* pStmt = 0;
+    int rc;
 
-  *ppApi = 0;
-  rc = sqlite3_prepare(db, "SELECT fts5(?1)", -1, &pStmt, 0);
-  if (rc == SQLITE_OK) {
-    sqlite3_bind_pointer(pStmt, 1, reinterpret_cast<void *>(ppApi), "fts5_api_ptr", 0);
-    (void)sqlite3_step(pStmt);
-    rc = sqlite3_finalize(pStmt);
-  }
+    *ppApi = 0;
+    rc = sqlite3_prepare(db, "SELECT fts5(?1)", -1, &pStmt, 0);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_pointer(pStmt, 1, reinterpret_cast<void*>(ppApi), "fts5_api_ptr", 0);
+        (void)sqlite3_step(pStmt);
+        rc = sqlite3_finalize(pStmt);
+    }
 
-  return rc;
+    return rc;
 }
 
 #ifdef USE_JIEBA
-static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  if (nVal >= 1) {
-    const char *text = (const char *)sqlite3_value_text(apVal[0]);
-    if (text) {
-      std::string tmp(text);
-      char sep = '/';
+static void jieba_dict(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
+    if (nVal >= 1) {
+        const char* text = (const char*)sqlite3_value_text(apVal[0]);
+        if (text) {
+            std::string tmp(text);
+            char sep = '/';
 #ifdef _WIN32
-      sep = '\\';
+            sep = '\\';
 #endif
-      if (tmp.back() != sep) {  // Need to add a
-        tmp += sep;             // path separator
-      }
-      simple_tokenizer::jieba_dict_path = tmp;
-      sqlite3_result_text(pCtx, tmp.c_str(), -1, SQLITE_TRANSIENT);
-      return;
+            if (tmp.back() != sep) {  // Need to add a
+                tmp += sep;           // path separator
+            }
+            simple_tokenizer::jieba_dict_path = tmp;
+            sqlite3_result_text(pCtx, tmp.c_str(), -1, SQLITE_TRANSIENT);
+            return;
+        }
     }
-  }
-  sqlite3_result_null(pCtx);
+    sqlite3_result_null(pCtx);
 }
 
 static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
@@ -94,16 +98,15 @@ static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
             result = keywords;
             break;
         case kSimple:
-            result = simple_tokenizer::SimpleTokenizer::tokenize_query(
-                keywords, std::strlen(keywords), using_pinyin ? 1 : 0);
+            result = simple_tokenizer::SimpleTokenizer::tokenize_query(keywords, std::strlen(keywords),
+                                                                       using_pinyin ? 1 : 0);
             break;
         case kJiebaCutWithHMM:
         case kJiebaCutWithoutHMM:
         case kJiebaCutAll:
         case kJiebaCutForSearch:
-            result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(
-                keywords, std::strlen(keywords), using_pinyin ? 1 : 0,
-                query_option);
+            result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(keywords, std::strlen(keywords),
+                                                                             using_pinyin ? 1 : 0, query_option);
             break;
         default:
             break;
@@ -112,65 +115,68 @@ static void query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
     sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
 }
 
-static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  if (nVal >= 1) {
-    const char *text = (const char *)sqlite3_value_text(apVal[0]);
-    if (text) {
-      int flags = 1;
-      if (nVal >= 2) {
-        flags = atoi((const char *)sqlite3_value_text(apVal[1]));
-      }
-      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(text, (int)std::strlen(text), flags);
-      sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
-      return;
+static void jieba_query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
+    if (nVal >= 1) {
+        const char* text = (const char*)sqlite3_value_text(apVal[0]);
+        if (text) {
+            int flags = 1;
+            if (nVal >= 2) {
+                flags = atoi((const char*)sqlite3_value_text(apVal[1]));
+            }
+            std::string result =
+                simple_tokenizer::SimpleTokenizer::tokenize_jieba_query(text, (int)std::strlen(text), flags);
+            sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
+            return;
+        }
     }
-  }
-  sqlite3_result_null(pCtx);
+    sqlite3_result_null(pCtx);
 }
 #endif
 
-static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
-  if (nVal >= 1) {
-    const char *text = (const char *)sqlite3_value_text(apVal[0]);
-    if (text) {
-      int flags = 1;
-      if (nVal >= 2) {
-        flags = atoi((const char *)sqlite3_value_text(apVal[1]));
-      }
-      std::string result = simple_tokenizer::SimpleTokenizer::tokenize_query(text, (int)std::strlen(text), flags);
-      sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
-      return;
+static void simple_query(sqlite3_context* pCtx, int nVal, sqlite3_value** apVal) {
+    if (nVal >= 1) {
+        const char* text = (const char*)sqlite3_value_text(apVal[0]);
+        if (text) {
+            int flags = 1;
+            if (nVal >= 2) {
+                flags = atoi((const char*)sqlite3_value_text(apVal[1]));
+            }
+            std::string result = simple_tokenizer::SimpleTokenizer::tokenize_query(text, (int)std::strlen(text), flags);
+            sqlite3_result_text(pCtx, result.c_str(), -1, SQLITE_TRANSIENT);
+            return;
+        }
     }
-  }
-  sqlite3_result_null(pCtx);
+    sqlite3_result_null(pCtx);
 }
 
-int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi) {
-  (void)pzErrMsg;
-  int rc = SQLITE_OK;
-  SQLITE_EXTENSION_INIT2(pApi)
+int sqlite3_simple_init(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi) {
+    (void)pzErrMsg;
+    int rc = SQLITE_OK;
+    SQLITE_EXTENSION_INIT2(pApi)
 
-  rc = sqlite3_create_function(db, "simple_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &simple_query, NULL,
-                               NULL);
+    rc = sqlite3_create_function(db, "simple_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &simple_query, NULL,
+                                 NULL);
 #ifdef USE_JIEBA
-  rc = sqlite3_create_function(db, "jieba_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_query, NULL,
-                               NULL);
-  rc = sqlite3_create_function(db, "jieba_dict", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_dict, NULL, NULL);
+    rc = sqlite3_create_function(db, "jieba_query", -1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_query, NULL,
+                                 NULL);
+    rc =
+        sqlite3_create_function(db, "jieba_dict", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC, NULL, &jieba_dict, NULL, NULL);
 #endif
 
-  // fts5_tokenizer tokenizer = {fts5AsciiCreate, fts5AsciiDelete, fts5AsciiTokenize };
-  fts5_tokenizer tokenizer = {fts5_simple_xCreate, fts5_simple_xDelete, fts5_simple_xTokenize};
-  fts5_api *fts5api;
-  rc = fts5_api_from_db(db, &fts5api);
-  if (rc != SQLITE_OK) return rc;
-  if (fts5api == 0 || fts5api->iVersion < 2) {
-    return SQLITE_ERROR;
-  }
-  rc = fts5api->xCreateTokenizer(fts5api, "simple", reinterpret_cast<void *>(fts5api), &tokenizer, NULL);
-  rc =
-      fts5api->xCreateFunction(fts5api, "simple_highlight", reinterpret_cast<void *>(fts5api), &simple_highlight, NULL);
-  rc = fts5api->xCreateFunction(fts5api, "simple_highlight_pos", reinterpret_cast<void *>(fts5api),
-                                &simple_highlight_pos, NULL);
-  rc = fts5api->xCreateFunction(fts5api, "simple_snippet", reinterpret_cast<void *>(fts5api), &simple_snippet, NULL);
-  return rc;
+    // fts5_tokenizer tokenizer = {fts5AsciiCreate, fts5AsciiDelete, fts5AsciiTokenize };
+    fts5_tokenizer tokenizer = {fts5_simple_xCreate, fts5_simple_xDelete, fts5_simple_xTokenize};
+    fts5_api* fts5api;
+    rc = fts5_api_from_db(db, &fts5api);
+    if (rc != SQLITE_OK)
+        return rc;
+    if (fts5api == 0 || fts5api->iVersion < 2) {
+        return SQLITE_ERROR;
+    }
+    rc = fts5api->xCreateTokenizer(fts5api, "simple", reinterpret_cast<void*>(fts5api), &tokenizer, NULL);
+    rc = fts5api->xCreateFunction(fts5api, "simple_highlight", reinterpret_cast<void*>(fts5api), &simple_highlight,
+                                  NULL);
+    rc = fts5api->xCreateFunction(fts5api, "simple_highlight_pos", reinterpret_cast<void*>(fts5api),
+                                  &simple_highlight_pos, NULL);
+    rc = fts5api->xCreateFunction(fts5api, "simple_snippet", reinterpret_cast<void*>(fts5api), &simple_snippet, NULL);
+    return rc;
 }

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -1,4 +1,5 @@
 #include "pinyin.h"
+
 #include <cmrc/cmrc.hpp>
 #include <map>
 #include <regex>
@@ -11,161 +12,144 @@ CMRC_DECLARE(pinyin_text);
 
 namespace simple_tokenizer {
 
-PinYin::PinYin() {
-    pinyin = build_pinyin_map();
-}
+PinYin::PinYin() { pinyin = build_pinyin_map(); }
 
-std::set<std::string> PinYin::to_plain(const std::string& input) {
-    std::set<std::string> s;
-    std::string value;
-    for (size_t i = 0, len = 0; i != input.length(); i += len) {
-        auto byte = input[i];
-        if (byte == ',') {
-            s.insert(value);
-            s.insert(value.substr(0, 1));
-            value.clear();
-            continue;
-        }
-        len = get_str_len((unsigned char)byte);
-        if (len == 1) {
-            value.push_back(byte);
-            continue;
-        }
-        auto it = tone_to_plain.find(input.substr(i, len));
-        if (it != tone_to_plain.end()) {
-            value.push_back(it->second);
-        } else {
-            value.push_back(byte);
-        }
+std::set<std::string> PinYin::to_plain(const std::string &input) {
+  std::set<std::string> s;
+  std::string value;
+  for (size_t i = 0, len = 0; i != input.length(); i += len) {
+    auto byte = input[i];
+    if (byte == ',') {
+      s.insert(value);
+      s.insert(value.substr(0, 1));
+      value.clear();
+      continue;
     }
-    s.insert(value);
-    s.insert(value.substr(0, 1));
-    return s;
+    len = get_str_len((unsigned char)byte);
+    if (len == 1) {
+      value.push_back(byte);
+      continue;
+    }
+    auto it = tone_to_plain.find(input.substr(i, len));
+    if (it != tone_to_plain.end()) {
+      value.push_back(it->second);
+    } else {
+      value.push_back(byte);
+    }
+  }
+  s.insert(value);
+  s.insert(value.substr(0, 1));
+  return s;
 }
 
 // clang-format off
 std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
   std::map<int, std::vector<std::string> > map;
-    // clang-format on
-    auto fs = cmrc::pinyin_text::get_filesystem();
-    auto pinyin_data = fs.open("contrib/pinyin.txt");
-    std::istringstream pinyin_file(
-        std::string(pinyin_data.begin(), pinyin_data.end()));
-    std::string line;
-    char delimiter = ' ';
-    std::string cp, py;
-    while (std::getline(pinyin_file, line)) {
-        if (line.length() == 0 || line[0] == '#')
-            continue;
-        std::stringstream tokenStream(line);
-        std::getline(tokenStream, cp, delimiter);
-        std::getline(tokenStream, py, delimiter);
-        int codepoint =
-            static_cast<int>(std::stoul(cp.substr(2, cp.length() - 3), 0, 16l));
-        std::set<std::string> s = to_plain(py);
-        std::vector<std::string> m(s.size());
-        std::copy(s.begin(), s.end(), m.begin());
-        map[codepoint] = m;
-    }
-    return map;
+  // clang-format on
+  auto fs = cmrc::pinyin_text::get_filesystem();
+  auto pinyin_data = fs.open("contrib/pinyin.txt");
+  std::istringstream pinyin_file(std::string(pinyin_data.begin(), pinyin_data.end()));
+  std::string line;
+  char delimiter = ' ';
+  std::string cp, py;
+  while (std::getline(pinyin_file, line)) {
+    if (line.length() == 0 || line[0] == '#') continue;
+    std::stringstream tokenStream(line);
+    std::getline(tokenStream, cp, delimiter);
+    std::getline(tokenStream, py, delimiter);
+    int codepoint = static_cast<int>(std::stoul(cp.substr(2, cp.length() - 3), 0, 16l));
+    std::set<std::string> s = to_plain(py);
+    std::vector<std::string> m(s.size());
+    std::copy(s.begin(), s.end(), m.begin());
+    map[codepoint] = m;
+  }
+  return map;
 }
 
 // Get UTF8 character encoding length(via first byte)
 int PinYin::get_str_len(unsigned char byte) {
-    if (byte >= 0xF0)
-        return 4;
-    else if (byte >= 0xE0)
-        return 3;
-    else if (byte >= 0xC0)
-        return 2;
-    return 1;
+  if (byte >= 0xF0)
+    return 4;
+  else if (byte >= 0xE0)
+    return 3;
+  else if (byte >= 0xC0)
+    return 2;
+  return 1;
 }
 
 // get the first valid utf8 string's code point
-int PinYin::codepoint(const std::string& u) {
-    size_t l = u.length();
-    if (l < 1)
-        return -1;
-    size_t len = get_str_len((unsigned char)u[0]);
-    if (l < len)
-        return -1;
-    switch (len) {
-        case 1:
-            return (unsigned char)u[0];
-        case 2:
-            return ((unsigned char)u[0] - 192) * 64 +
-                   ((unsigned char)u[1] - 128);
-        case 3:  // most Chinese char in here
-            return ((unsigned char)u[0] - 224) * 4096 +
-                   ((unsigned char)u[1] - 128) * 64 +
-                   ((unsigned char)u[2] - 128);
-        case 4:
-            return ((unsigned char)u[0] - 240) * 262144 +
-                   ((unsigned char)u[1] - 128) * 4096 +
-                   ((unsigned char)u[2] - 128) * 64 +
-                   ((unsigned char)u[3] - 128);
-        default:
-            throw std::runtime_error("should never happen");
-    }
+int PinYin::codepoint(const std::string &u) {
+  size_t l = u.length();
+  if (l < 1) return -1;
+  size_t len = get_str_len((unsigned char)u[0]);
+  if (l < len) return -1;
+  switch (len) {
+    case 1:
+      return (unsigned char)u[0];
+    case 2:
+      return ((unsigned char)u[0] - 192) * 64 + ((unsigned char)u[1] - 128);
+    case 3:  // most Chinese char in here
+      return ((unsigned char)u[0] - 224) * 4096 + ((unsigned char)u[1] - 128) * 64 + ((unsigned char)u[2] - 128);
+    case 4:
+      return ((unsigned char)u[0] - 240) * 262144 + ((unsigned char)u[1] - 128) * 4096 +
+             ((unsigned char)u[2] - 128) * 64 + ((unsigned char)u[3] - 128);
+    default:
+      throw std::runtime_error("should never happen");
+  }
 }
 
-const std::vector<std::string>& PinYin::get_pinyin(const std::string& chinese) {
-    return pinyin[codepoint(chinese)];
+const std::vector<std::string> &PinYin::get_pinyin(const std::string &chinese) { return pinyin[codepoint(chinese)]; }
+
+std::vector<std::string> PinYin::_split_pinyin(const std::string &input, int begin, int end) {
+  if (begin >= end) {
+    return empty_vector;
+  }
+  if (begin == end - 1) {
+    return {input.substr(begin, end - begin)};
+  }
+  std::vector<std::string> result;
+  std::string full = input.substr(begin, end - begin);
+  if (pinyin_prefix.find(full) != pinyin_prefix.end() || pinyin_valid.find(full) != pinyin_valid.end()) {
+    result.push_back(full);
+  }
+  int start = begin + 1;
+  while (start < end) {
+    std::string first = input.substr(begin, start - begin);
+    if (pinyin_valid.find(first) == pinyin_valid.end()) {
+      ++start;
+      continue;
+    }
+    std::vector<std::string> tmp = _split_pinyin(input, start, end);
+    for (const auto &s : tmp) {
+      result.push_back(first + "+" + s);
+    }
+    ++start;
+  }
+  return result;
 }
 
-std::vector<std::string> PinYin::_split_pinyin(const std::string& input,
-                                               int begin,
-                                               int end) {
-    if (begin >= end) {
-        return empty_vector;
-    }
-    if (begin == end - 1) {
-        return {input.substr(begin, end - begin)};
-    }
-    std::vector<std::string> result;
-    std::string full = input.substr(begin, end - begin);
-    if (pinyin_prefix.find(full) != pinyin_prefix.end() ||
-        pinyin_valid.find(full) != pinyin_valid.end()) {
-        result.push_back(full);
-    }
-    int start = begin + 1;
-    while (start < end) {
-        std::string first = input.substr(begin, start - begin);
-        if (pinyin_valid.find(first) == pinyin_valid.end()) {
-            ++start;
-            continue;
-        }
-        std::vector<std::string> tmp = _split_pinyin(input, start, end);
-        for (const auto& s : tmp) {
-            result.push_back(first + "+" + s);
-        }
-        ++start;
-    }
-    return result;
-}
+std::set<std::string> PinYin::split_pinyin(const std::string &input) {
+  int slen = (int)input.size();
+  const int max_length = 20;
+  if (slen > max_length || slen <= 1) {
+    return {input};
+  }
 
-std::set<std::string> PinYin::split_pinyin(const std::string& input) {
-    int slen = (int)input.size();
-    const int max_length = 20;
-    if (slen > max_length || slen <= 1) {
-        return {input};
-    }
+  std::string spacedInput;
+  for (auto c : input) {
+    spacedInput.push_back('+');
+    spacedInput.push_back(c);
+  }
+  spacedInput = spacedInput.substr(1, spacedInput.size());
 
-    std::string spacedInput;
-    for (auto c : input) {
-        spacedInput.push_back('+');
-        spacedInput.push_back(c);
-    }
-    spacedInput = spacedInput.substr(1, spacedInput.size());
-
-    if (slen > 2) {
-        std::vector<std::string> tmp = _split_pinyin(input, 0, slen);
-        std::set<std::string> s(tmp.begin(), tmp.end());
-        s.insert(spacedInput);
-        s.insert(input);
-        return s;
-    }
-    return {input, spacedInput};
+  if (slen > 2) {
+    std::vector<std::string> tmp = _split_pinyin(input, 0, slen);
+    std::set<std::string> s(tmp.begin(), tmp.end());
+    s.insert(spacedInput);
+    s.insert(input);
+    return s;
+  }
+  return {input, spacedInput};
 }
 
 }  // namespace simple_tokenizer

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -1,5 +1,4 @@
 #include "pinyin.h"
-
 #include <cmrc/cmrc.hpp>
 #include <map>
 #include <regex>
@@ -12,144 +11,161 @@ CMRC_DECLARE(pinyin_text);
 
 namespace simple_tokenizer {
 
-PinYin::PinYin() { pinyin = build_pinyin_map(); }
+PinYin::PinYin() {
+    pinyin = build_pinyin_map();
+}
 
-std::set<std::string> PinYin::to_plain(const std::string &input) {
-  std::set<std::string> s;
-  std::string value;
-  for (size_t i = 0, len = 0; i != input.length(); i += len) {
-    auto byte = input[i];
-    if (byte == ',') {
-      s.insert(value);
-      s.insert(value.substr(0, 1));
-      value.clear();
-      continue;
+std::set<std::string> PinYin::to_plain(const std::string& input) {
+    std::set<std::string> s;
+    std::string value;
+    for (size_t i = 0, len = 0; i != input.length(); i += len) {
+        auto byte = input[i];
+        if (byte == ',') {
+            s.insert(value);
+            s.insert(value.substr(0, 1));
+            value.clear();
+            continue;
+        }
+        len = get_str_len((unsigned char)byte);
+        if (len == 1) {
+            value.push_back(byte);
+            continue;
+        }
+        auto it = tone_to_plain.find(input.substr(i, len));
+        if (it != tone_to_plain.end()) {
+            value.push_back(it->second);
+        } else {
+            value.push_back(byte);
+        }
     }
-    len = get_str_len((unsigned char)byte);
-    if (len == 1) {
-      value.push_back(byte);
-      continue;
-    }
-    auto it = tone_to_plain.find(input.substr(i, len));
-    if (it != tone_to_plain.end()) {
-      value.push_back(it->second);
-    } else {
-      value.push_back(byte);
-    }
-  }
-  s.insert(value);
-  s.insert(value.substr(0, 1));
-  return s;
+    s.insert(value);
+    s.insert(value.substr(0, 1));
+    return s;
 }
 
 // clang-format off
 std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
   std::map<int, std::vector<std::string> > map;
-  // clang-format on
-  auto fs = cmrc::pinyin_text::get_filesystem();
-  auto pinyin_data = fs.open("contrib/pinyin.txt");
-  std::istringstream pinyin_file(std::string(pinyin_data.begin(), pinyin_data.end()));
-  std::string line;
-  char delimiter = ' ';
-  std::string cp, py;
-  while (std::getline(pinyin_file, line)) {
-    if (line.length() == 0 || line[0] == '#') continue;
-    std::stringstream tokenStream(line);
-    std::getline(tokenStream, cp, delimiter);
-    std::getline(tokenStream, py, delimiter);
-    int codepoint = static_cast<int>(std::stoul(cp.substr(2, cp.length() - 3), 0, 16l));
-    std::set<std::string> s = to_plain(py);
-    std::vector<std::string> m(s.size());
-    std::copy(s.begin(), s.end(), m.begin());
-    map[codepoint] = m;
-  }
-  return map;
+    // clang-format on
+    auto fs = cmrc::pinyin_text::get_filesystem();
+    auto pinyin_data = fs.open("contrib/pinyin.txt");
+    std::istringstream pinyin_file(
+        std::string(pinyin_data.begin(), pinyin_data.end()));
+    std::string line;
+    char delimiter = ' ';
+    std::string cp, py;
+    while (std::getline(pinyin_file, line)) {
+        if (line.length() == 0 || line[0] == '#')
+            continue;
+        std::stringstream tokenStream(line);
+        std::getline(tokenStream, cp, delimiter);
+        std::getline(tokenStream, py, delimiter);
+        int codepoint =
+            static_cast<int>(std::stoul(cp.substr(2, cp.length() - 3), 0, 16l));
+        std::set<std::string> s = to_plain(py);
+        std::vector<std::string> m(s.size());
+        std::copy(s.begin(), s.end(), m.begin());
+        map[codepoint] = m;
+    }
+    return map;
 }
 
 // Get UTF8 character encoding length(via first byte)
 int PinYin::get_str_len(unsigned char byte) {
-  if (byte >= 0xF0)
-    return 4;
-  else if (byte >= 0xE0)
-    return 3;
-  else if (byte >= 0xC0)
-    return 2;
-  return 1;
+    if (byte >= 0xF0)
+        return 4;
+    else if (byte >= 0xE0)
+        return 3;
+    else if (byte >= 0xC0)
+        return 2;
+    return 1;
 }
 
 // get the first valid utf8 string's code point
-int PinYin::codepoint(const std::string &u) {
-  size_t l = u.length();
-  if (l < 1) return -1;
-  size_t len = get_str_len((unsigned char)u[0]);
-  if (l < len) return -1;
-  switch (len) {
-    case 1:
-      return (unsigned char)u[0];
-    case 2:
-      return ((unsigned char)u[0] - 192) * 64 + ((unsigned char)u[1] - 128);
-    case 3:  // most Chinese char in here
-      return ((unsigned char)u[0] - 224) * 4096 + ((unsigned char)u[1] - 128) * 64 + ((unsigned char)u[2] - 128);
-    case 4:
-      return ((unsigned char)u[0] - 240) * 262144 + ((unsigned char)u[1] - 128) * 4096 +
-             ((unsigned char)u[2] - 128) * 64 + ((unsigned char)u[3] - 128);
-    default:
-      throw std::runtime_error("should never happen");
-  }
+int PinYin::codepoint(const std::string& u) {
+    size_t l = u.length();
+    if (l < 1)
+        return -1;
+    size_t len = get_str_len((unsigned char)u[0]);
+    if (l < len)
+        return -1;
+    switch (len) {
+        case 1:
+            return (unsigned char)u[0];
+        case 2:
+            return ((unsigned char)u[0] - 192) * 64 +
+                   ((unsigned char)u[1] - 128);
+        case 3:  // most Chinese char in here
+            return ((unsigned char)u[0] - 224) * 4096 +
+                   ((unsigned char)u[1] - 128) * 64 +
+                   ((unsigned char)u[2] - 128);
+        case 4:
+            return ((unsigned char)u[0] - 240) * 262144 +
+                   ((unsigned char)u[1] - 128) * 4096 +
+                   ((unsigned char)u[2] - 128) * 64 +
+                   ((unsigned char)u[3] - 128);
+        default:
+            throw std::runtime_error("should never happen");
+    }
 }
 
-const std::vector<std::string> &PinYin::get_pinyin(const std::string &chinese) { return pinyin[codepoint(chinese)]; }
-
-std::vector<std::string> PinYin::_split_pinyin(const std::string &input, int begin, int end) {
-  if (begin >= end) {
-    return empty_vector;
-  }
-  if (begin == end - 1) {
-    return {input.substr(begin, end - begin)};
-  }
-  std::vector<std::string> result;
-  std::string full = input.substr(begin, end - begin);
-  if (pinyin_prefix.find(full) != pinyin_prefix.end() || pinyin_valid.find(full) != pinyin_valid.end()) {
-    result.push_back(full);
-  }
-  int start = begin + 1;
-  while (start < end) {
-    std::string first = input.substr(begin, start - begin);
-    if (pinyin_valid.find(first) == pinyin_valid.end()) {
-      ++start;
-      continue;
-    }
-    std::vector<std::string> tmp = _split_pinyin(input, start, end);
-    for (const auto &s : tmp) {
-      result.push_back(first + "+" + s);
-    }
-    ++start;
-  }
-  return result;
+const std::vector<std::string>& PinYin::get_pinyin(const std::string& chinese) {
+    return pinyin[codepoint(chinese)];
 }
 
-std::set<std::string> PinYin::split_pinyin(const std::string &input) {
-  int slen = (int)input.size();
-  const int max_length = 20;
-  if (slen > max_length || slen <= 1) {
-    return {input};
-  }
+std::vector<std::string> PinYin::_split_pinyin(const std::string& input,
+                                               int begin,
+                                               int end) {
+    if (begin >= end) {
+        return empty_vector;
+    }
+    if (begin == end - 1) {
+        return {input.substr(begin, end - begin)};
+    }
+    std::vector<std::string> result;
+    std::string full = input.substr(begin, end - begin);
+    if (pinyin_prefix.find(full) != pinyin_prefix.end() ||
+        pinyin_valid.find(full) != pinyin_valid.end()) {
+        result.push_back(full);
+    }
+    int start = begin + 1;
+    while (start < end) {
+        std::string first = input.substr(begin, start - begin);
+        if (pinyin_valid.find(first) == pinyin_valid.end()) {
+            ++start;
+            continue;
+        }
+        std::vector<std::string> tmp = _split_pinyin(input, start, end);
+        for (const auto& s : tmp) {
+            result.push_back(first + "+" + s);
+        }
+        ++start;
+    }
+    return result;
+}
 
-  std::string spacedInput;
-  for (auto c : input) {
-    spacedInput.push_back('+');
-    spacedInput.push_back(c);
-  }
-  spacedInput = spacedInput.substr(1, spacedInput.size());
+std::set<std::string> PinYin::split_pinyin(const std::string& input) {
+    int slen = (int)input.size();
+    const int max_length = 20;
+    if (slen > max_length || slen <= 1) {
+        return {input};
+    }
 
-  if (slen > 2) {
-    std::vector<std::string> tmp = _split_pinyin(input, 0, slen);
-    std::set<std::string> s(tmp.begin(), tmp.end());
-    s.insert(spacedInput);
-    s.insert(input);
-    return s;
-  }
-  return {input, spacedInput};
+    std::string spacedInput;
+    for (auto c : input) {
+        spacedInput.push_back('+');
+        spacedInput.push_back(c);
+    }
+    spacedInput = spacedInput.substr(1, spacedInput.size());
+
+    if (slen > 2) {
+        std::vector<std::string> tmp = _split_pinyin(input, 0, slen);
+        std::set<std::string> s(tmp.begin(), tmp.end());
+        s.insert(spacedInput);
+        s.insert(input);
+        return s;
+    }
+    return {input, spacedInput};
 }
 
 }  // namespace simple_tokenizer

--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -1,5 +1,4 @@
 #include "pinyin.h"
-
 #include <cmrc/cmrc.hpp>
 #include <map>
 #include <regex>
@@ -12,144 +11,151 @@ CMRC_DECLARE(pinyin_text);
 
 namespace simple_tokenizer {
 
-PinYin::PinYin() { pinyin = build_pinyin_map(); }
+PinYin::PinYin() {
+    pinyin = build_pinyin_map();
+}
 
-std::set<std::string> PinYin::to_plain(const std::string &input) {
-  std::set<std::string> s;
-  std::string value;
-  for (size_t i = 0, len = 0; i != input.length(); i += len) {
-    auto byte = input[i];
-    if (byte == ',') {
-      s.insert(value);
-      s.insert(value.substr(0, 1));
-      value.clear();
-      continue;
+std::set<std::string> PinYin::to_plain(const std::string& input) {
+    std::set<std::string> s;
+    std::string value;
+    for (size_t i = 0, len = 0; i != input.length(); i += len) {
+        auto byte = input[i];
+        if (byte == ',') {
+            s.insert(value);
+            s.insert(value.substr(0, 1));
+            value.clear();
+            continue;
+        }
+        len = get_str_len((unsigned char)byte);
+        if (len == 1) {
+            value.push_back(byte);
+            continue;
+        }
+        auto it = tone_to_plain.find(input.substr(i, len));
+        if (it != tone_to_plain.end()) {
+            value.push_back(it->second);
+        } else {
+            value.push_back(byte);
+        }
     }
-    len = get_str_len((unsigned char)byte);
-    if (len == 1) {
-      value.push_back(byte);
-      continue;
-    }
-    auto it = tone_to_plain.find(input.substr(i, len));
-    if (it != tone_to_plain.end()) {
-      value.push_back(it->second);
-    } else {
-      value.push_back(byte);
-    }
-  }
-  s.insert(value);
-  s.insert(value.substr(0, 1));
-  return s;
+    s.insert(value);
+    s.insert(value.substr(0, 1));
+    return s;
 }
 
 // clang-format off
 std::map<int, std::vector<std::string> > PinYin::build_pinyin_map() {
   std::map<int, std::vector<std::string> > map;
-  // clang-format on
-  auto fs = cmrc::pinyin_text::get_filesystem();
-  auto pinyin_data = fs.open("contrib/pinyin.txt");
-  std::istringstream pinyin_file(std::string(pinyin_data.begin(), pinyin_data.end()));
-  std::string line;
-  char delimiter = ' ';
-  std::string cp, py;
-  while (std::getline(pinyin_file, line)) {
-    if (line.length() == 0 || line[0] == '#') continue;
-    std::stringstream tokenStream(line);
-    std::getline(tokenStream, cp, delimiter);
-    std::getline(tokenStream, py, delimiter);
-    int codepoint = static_cast<int>(std::stoul(cp.substr(2, cp.length() - 3), 0, 16l));
-    std::set<std::string> s = to_plain(py);
-    std::vector<std::string> m(s.size());
-    std::copy(s.begin(), s.end(), m.begin());
-    map[codepoint] = m;
-  }
-  return map;
+    // clang-format on
+    auto fs = cmrc::pinyin_text::get_filesystem();
+    auto pinyin_data = fs.open("contrib/pinyin.txt");
+    std::istringstream pinyin_file(std::string(pinyin_data.begin(), pinyin_data.end()));
+    std::string line;
+    char delimiter = ' ';
+    std::string cp, py;
+    while (std::getline(pinyin_file, line)) {
+        if (line.length() == 0 || line[0] == '#')
+            continue;
+        std::stringstream tokenStream(line);
+        std::getline(tokenStream, cp, delimiter);
+        std::getline(tokenStream, py, delimiter);
+        int codepoint = static_cast<int>(std::stoul(cp.substr(2, cp.length() - 3), 0, 16l));
+        std::set<std::string> s = to_plain(py);
+        std::vector<std::string> m(s.size());
+        std::copy(s.begin(), s.end(), m.begin());
+        map[codepoint] = m;
+    }
+    return map;
 }
 
 // Get UTF8 character encoding length(via first byte)
 int PinYin::get_str_len(unsigned char byte) {
-  if (byte >= 0xF0)
-    return 4;
-  else if (byte >= 0xE0)
-    return 3;
-  else if (byte >= 0xC0)
-    return 2;
-  return 1;
+    if (byte >= 0xF0)
+        return 4;
+    else if (byte >= 0xE0)
+        return 3;
+    else if (byte >= 0xC0)
+        return 2;
+    return 1;
 }
 
 // get the first valid utf8 string's code point
-int PinYin::codepoint(const std::string &u) {
-  size_t l = u.length();
-  if (l < 1) return -1;
-  size_t len = get_str_len((unsigned char)u[0]);
-  if (l < len) return -1;
-  switch (len) {
-    case 1:
-      return (unsigned char)u[0];
-    case 2:
-      return ((unsigned char)u[0] - 192) * 64 + ((unsigned char)u[1] - 128);
-    case 3:  // most Chinese char in here
-      return ((unsigned char)u[0] - 224) * 4096 + ((unsigned char)u[1] - 128) * 64 + ((unsigned char)u[2] - 128);
-    case 4:
-      return ((unsigned char)u[0] - 240) * 262144 + ((unsigned char)u[1] - 128) * 4096 +
-             ((unsigned char)u[2] - 128) * 64 + ((unsigned char)u[3] - 128);
-    default:
-      throw std::runtime_error("should never happen");
-  }
+int PinYin::codepoint(const std::string& u) {
+    size_t l = u.length();
+    if (l < 1)
+        return -1;
+    size_t len = get_str_len((unsigned char)u[0]);
+    if (l < len)
+        return -1;
+    switch (len) {
+        case 1:
+            return (unsigned char)u[0];
+        case 2:
+            return ((unsigned char)u[0] - 192) * 64 + ((unsigned char)u[1] - 128);
+        case 3:  // most Chinese char in here
+            return ((unsigned char)u[0] - 224) * 4096 + ((unsigned char)u[1] - 128) * 64 + ((unsigned char)u[2] - 128);
+        case 4:
+            return ((unsigned char)u[0] - 240) * 262144 + ((unsigned char)u[1] - 128) * 4096 +
+                   ((unsigned char)u[2] - 128) * 64 + ((unsigned char)u[3] - 128);
+        default:
+            throw std::runtime_error("should never happen");
+    }
 }
 
-const std::vector<std::string> &PinYin::get_pinyin(const std::string &chinese) { return pinyin[codepoint(chinese)]; }
-
-std::vector<std::string> PinYin::_split_pinyin(const std::string &input, int begin, int end) {
-  if (begin >= end) {
-    return empty_vector;
-  }
-  if (begin == end - 1) {
-    return {input.substr(begin, end - begin)};
-  }
-  std::vector<std::string> result;
-  std::string full = input.substr(begin, end - begin);
-  if (pinyin_prefix.find(full) != pinyin_prefix.end() || pinyin_valid.find(full) != pinyin_valid.end()) {
-    result.push_back(full);
-  }
-  int start = begin + 1;
-  while (start < end) {
-    std::string first = input.substr(begin, start - begin);
-    if (pinyin_valid.find(first) == pinyin_valid.end()) {
-      ++start;
-      continue;
-    }
-    std::vector<std::string> tmp = _split_pinyin(input, start, end);
-    for (const auto &s : tmp) {
-      result.push_back(first + "+" + s);
-    }
-    ++start;
-  }
-  return result;
+const std::vector<std::string>& PinYin::get_pinyin(const std::string& chinese) {
+    return pinyin[codepoint(chinese)];
 }
 
-std::set<std::string> PinYin::split_pinyin(const std::string &input) {
-  int slen = (int)input.size();
-  const int max_length = 20;
-  if (slen > max_length || slen <= 1) {
-    return {input};
-  }
+std::vector<std::string> PinYin::_split_pinyin(const std::string& input, int begin, int end) {
+    if (begin >= end) {
+        return empty_vector;
+    }
+    if (begin == end - 1) {
+        return {input.substr(begin, end - begin)};
+    }
+    std::vector<std::string> result;
+    std::string full = input.substr(begin, end - begin);
+    if (pinyin_prefix.find(full) != pinyin_prefix.end() || pinyin_valid.find(full) != pinyin_valid.end()) {
+        result.push_back(full);
+    }
+    int start = begin + 1;
+    while (start < end) {
+        std::string first = input.substr(begin, start - begin);
+        if (pinyin_valid.find(first) == pinyin_valid.end()) {
+            ++start;
+            continue;
+        }
+        std::vector<std::string> tmp = _split_pinyin(input, start, end);
+        for (const auto& s : tmp) {
+            result.push_back(first + "+" + s);
+        }
+        ++start;
+    }
+    return result;
+}
 
-  std::string spacedInput;
-  for (auto c : input) {
-    spacedInput.push_back('+');
-    spacedInput.push_back(c);
-  }
-  spacedInput = spacedInput.substr(1, spacedInput.size());
+std::set<std::string> PinYin::split_pinyin(const std::string& input) {
+    int slen = (int)input.size();
+    const int max_length = 20;
+    if (slen > max_length || slen <= 1) {
+        return {input};
+    }
 
-  if (slen > 2) {
-    std::vector<std::string> tmp = _split_pinyin(input, 0, slen);
-    std::set<std::string> s(tmp.begin(), tmp.end());
-    s.insert(spacedInput);
-    s.insert(input);
-    return s;
-  }
-  return {input, spacedInput};
+    std::string spacedInput;
+    for (auto c : input) {
+        spacedInput.push_back('+');
+        spacedInput.push_back(c);
+    }
+    spacedInput = spacedInput.substr(1, spacedInput.size());
+
+    if (slen > 2) {
+        std::vector<std::string> tmp = _split_pinyin(input, 0, slen);
+        std::set<std::string> s(tmp.begin(), tmp.end());
+        s.insert(spacedInput);
+        s.insert(input);
+        return s;
+    }
+    return {input, spacedInput};
 }
 
 }  // namespace simple_tokenizer

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -9,11 +9,11 @@
 namespace simple_tokenizer {
 
 class PinYin {
- private:
-  std::map<int, std::vector<std::string> > pinyin;
-  const std::vector<std::string> empty_vector;
+private:
+    std::map<int, std::vector<std::string> > pinyin;
+    const std::vector<std::string> empty_vector;
 
-  // clang-format off
+    // clang-format off
   const std::map<std::string, char> tone_to_plain = {
       {"ā", 'a'}, {"á", 'a'}, {"ǎ", 'a'}, {"à", 'a'},
       {"ē", 'e'}, {"é", 'e'}, {"ě", 'e'}, {"è", 'e'},
@@ -104,17 +104,19 @@ class PinYin {
               "zhuan", "zhuang", "zhui", "zhun", "zhuo", "zi", "zong", "zou", "zu", "zuan",
         "zui", "zun", "zuo",
     };
-  // clang-format on
-  std::set<std::string> to_plain(const std::string &input);
-  std::map<int, std::vector<std::string> > build_pinyin_map();
-  static int codepoint(const std::string &u);
-  std::vector<std::string> _split_pinyin(const std::string &input, int begin, int end);
+    // clang-format on
+    std::set<std::string> to_plain(const std::string& input);
+    std::map<int, std::vector<std::string> > build_pinyin_map();
+    static int codepoint(const std::string& u);
+    std::vector<std::string> _split_pinyin(const std::string& input,
+                                           int begin,
+                                           int end);
 
- public:
-  const std::vector<std::string> &get_pinyin(const std::string &chinese);
-  static int get_str_len(unsigned char byte);
-  std::set<std::string> split_pinyin(const std::string &input);
-  PinYin();
+public:
+    const std::vector<std::string>& get_pinyin(const std::string& chinese);
+    static int get_str_len(unsigned char byte);
+    std::set<std::string> split_pinyin(const std::string& input);
+    PinYin();
 };
 
 }  // namespace simple_tokenizer

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -9,11 +9,11 @@
 namespace simple_tokenizer {
 
 class PinYin {
-private:
-    std::map<int, std::vector<std::string> > pinyin;
-    const std::vector<std::string> empty_vector;
+ private:
+  std::map<int, std::vector<std::string> > pinyin;
+  const std::vector<std::string> empty_vector;
 
-    // clang-format off
+  // clang-format off
   const std::map<std::string, char> tone_to_plain = {
       {"ā", 'a'}, {"á", 'a'}, {"ǎ", 'a'}, {"à", 'a'},
       {"ē", 'e'}, {"é", 'e'}, {"ě", 'e'}, {"è", 'e'},
@@ -104,19 +104,17 @@ private:
               "zhuan", "zhuang", "zhui", "zhun", "zhuo", "zi", "zong", "zou", "zu", "zuan",
         "zui", "zun", "zuo",
     };
-    // clang-format on
-    std::set<std::string> to_plain(const std::string& input);
-    std::map<int, std::vector<std::string> > build_pinyin_map();
-    static int codepoint(const std::string& u);
-    std::vector<std::string> _split_pinyin(const std::string& input,
-                                           int begin,
-                                           int end);
+  // clang-format on
+  std::set<std::string> to_plain(const std::string &input);
+  std::map<int, std::vector<std::string> > build_pinyin_map();
+  static int codepoint(const std::string &u);
+  std::vector<std::string> _split_pinyin(const std::string &input, int begin, int end);
 
-public:
-    const std::vector<std::string>& get_pinyin(const std::string& chinese);
-    static int get_str_len(unsigned char byte);
-    std::set<std::string> split_pinyin(const std::string& input);
-    PinYin();
+ public:
+  const std::vector<std::string> &get_pinyin(const std::string &chinese);
+  static int get_str_len(unsigned char byte);
+  std::set<std::string> split_pinyin(const std::string &input);
+  PinYin();
 };
 
 }  // namespace simple_tokenizer

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -9,11 +9,11 @@
 namespace simple_tokenizer {
 
 class PinYin {
- private:
-  std::map<int, std::vector<std::string> > pinyin;
-  const std::vector<std::string> empty_vector;
+private:
+    std::map<int, std::vector<std::string> > pinyin;
+    const std::vector<std::string> empty_vector;
 
-  // clang-format off
+    // clang-format off
   const std::map<std::string, char> tone_to_plain = {
       {"ā", 'a'}, {"á", 'a'}, {"ǎ", 'a'}, {"à", 'a'},
       {"ē", 'e'}, {"é", 'e'}, {"ě", 'e'}, {"è", 'e'},
@@ -104,17 +104,17 @@ class PinYin {
               "zhuan", "zhuang", "zhui", "zhun", "zhuo", "zi", "zong", "zou", "zu", "zuan",
         "zui", "zun", "zuo",
     };
-  // clang-format on
-  std::set<std::string> to_plain(const std::string &input);
-  std::map<int, std::vector<std::string> > build_pinyin_map();
-  static int codepoint(const std::string &u);
-  std::vector<std::string> _split_pinyin(const std::string &input, int begin, int end);
+    // clang-format on
+    std::set<std::string> to_plain(const std::string& input);
+    std::map<int, std::vector<std::string> > build_pinyin_map();
+    static int codepoint(const std::string& u);
+    std::vector<std::string> _split_pinyin(const std::string& input, int begin, int end);
 
- public:
-  const std::vector<std::string> &get_pinyin(const std::string &chinese);
-  static int get_str_len(unsigned char byte);
-  std::set<std::string> split_pinyin(const std::string &input);
-  PinYin();
+public:
+    const std::vector<std::string>& get_pinyin(const std::string& chinese);
+    static int get_str_len(unsigned char byte);
+    std::set<std::string> split_pinyin(const std::string& input);
+    PinYin();
 };
 
 }  // namespace simple_tokenizer

--- a/src/simple_def.h
+++ b/src/simple_def.h
@@ -1,0 +1,26 @@
+/**
+ * @file entry.h
+ * @author Dylan
+ * @brief
+ * @version 0.1
+ * @date 2021-07-15
+ *
+ * @copyright Copyright (c) 2021
+ *
+ */
+
+#ifndef SRC_ENTRY_H_
+#define SRC_ENTRY_H_
+
+enum QueryOption {
+    kDefault,
+    kSimple,
+    kJiebaCutWithHMM,
+    kJiebaCutWithoutHMM,
+    kJiebaCutAll,
+    kJiebaCutForSearch,
+    kJiebaCutHMM,
+    kJiebaCutSmall
+};
+
+#endif  // SRC_ENTRY_H_

--- a/src/simple_highlight.cc
+++ b/src/simple_highlight.cc
@@ -50,68 +50,74 @@ SQLITE_EXTENSION_INIT3
 */
 typedef struct CInstIter CInstIter;
 struct CInstIter {
-  const Fts5ExtensionApi *pApi; /* API offered by current FTS version */
-  Fts5Context *pFts;            /* First arg to pass to pApi functions */
-  int iCol;                     /* Column to search */
-  int iInst;                    /* Next phrase instance index */
-  int nInst;                    /* Total number of phrase instances */
+    const Fts5ExtensionApi* pApi; /* API offered by current FTS version */
+    Fts5Context* pFts;            /* First arg to pass to pApi functions */
+    int iCol;                     /* Column to search */
+    int iInst;                    /* Next phrase instance index */
+    int nInst;                    /* Total number of phrase instances */
 
-  /* Output variables */
-  int iStart; /* First token in coalesced phrase instance */
-  int iEnd;   /* Last token in coalesced phrase instance */
+    /* Output variables */
+    int iStart; /* First token in coalesced phrase instance */
+    int iEnd;   /* Last token in coalesced phrase instance */
 };
 
 /*
 ** Advance the iterator to the next coalesced phrase instance. Return
 ** an SQLite error code if an error occurs, or SQLITE_OK otherwise.
 */
-static int fts5CInstIterNext(CInstIter *pIter) {
-  int rc = SQLITE_OK;
-  pIter->iStart = -1;
-  pIter->iEnd = -1;
+static int fts5CInstIterNext(CInstIter* pIter) {
+    int rc = SQLITE_OK;
+    pIter->iStart = -1;
+    pIter->iEnd = -1;
 
-  while (rc == SQLITE_OK && pIter->iInst < pIter->nInst) {
-    int ip;
-    int ic;
-    int io;
-    rc = pIter->pApi->xInst(pIter->pFts, pIter->iInst, &ip, &ic, &io);
-    if (rc == SQLITE_OK) {
-      if (ic == pIter->iCol) {
-        int iEnd = io - 1 + pIter->pApi->xPhraseSize(pIter->pFts, ip);
-        if (pIter->iStart < 0) {
-          pIter->iStart = io;
-          pIter->iEnd = iEnd;
-        } else if (io <= pIter->iEnd + 1) {  // NOTE: +1 is the only diff with buildin highlight function
-          if (iEnd > pIter->iEnd) pIter->iEnd = iEnd;
-        } else {
-          break;
+    while (rc == SQLITE_OK && pIter->iInst < pIter->nInst) {
+        int ip;
+        int ic;
+        int io;
+        rc = pIter->pApi->xInst(pIter->pFts, pIter->iInst, &ip, &ic, &io);
+        if (rc == SQLITE_OK) {
+            if (ic == pIter->iCol) {
+                int iEnd = io - 1 + pIter->pApi->xPhraseSize(pIter->pFts, ip);
+                if (pIter->iStart < 0) {
+                    pIter->iStart = io;
+                    pIter->iEnd = iEnd;
+                } else if (io <=
+                           pIter->iEnd + 1) {  // NOTE: +1 is the only diff with
+                                               // buildin highlight function
+                    if (iEnd > pIter->iEnd)
+                        pIter->iEnd = iEnd;
+                } else {
+                    break;
+                }
+            }
+            pIter->iInst++;
         }
-      }
-      pIter->iInst++;
     }
-  }
 
-  return rc;
+    return rc;
 }
 
 /*
 ** Initialize the iterator object indicated by the final parameter to
 ** iterate through coalesced phrase instances in column iCol.
 */
-static int fts5CInstIterInit(const Fts5ExtensionApi *pApi, Fts5Context *pFts, int iCol, CInstIter *pIter) {
-  int rc;
+static int fts5CInstIterInit(const Fts5ExtensionApi* pApi,
+                             Fts5Context* pFts,
+                             int iCol,
+                             CInstIter* pIter) {
+    int rc;
 
-  memset(pIter, 0, sizeof(CInstIter));
-  pIter->pApi = pApi;
-  pIter->pFts = pFts;
-  pIter->iCol = iCol;
-  rc = pApi->xInstCount(pFts, &pIter->nInst);
+    memset(pIter, 0, sizeof(CInstIter));
+    pIter->pApi = pApi;
+    pIter->pFts = pFts;
+    pIter->iCol = iCol;
+    rc = pApi->xInstCount(pFts, &pIter->nInst);
 
-  if (rc == SQLITE_OK) {
-    rc = fts5CInstIterNext(pIter);
-  }
+    if (rc == SQLITE_OK) {
+        rc = fts5CInstIterNext(pIter);
+    }
 
-  return rc;
+    return rc;
 }
 
 /*************************************************************************
@@ -119,16 +125,16 @@ static int fts5CInstIterInit(const Fts5ExtensionApi *pApi, Fts5Context *pFts, in
 */
 typedef struct HighlightContext HighlightContext;
 struct HighlightContext {
-  CInstIter iter;     /* Coalesced Instance Iterator */
-  int iPos;           /* Current token offset in zIn[] */
-  int iRangeStart;    /* First token to include */
-  int iRangeEnd;      /* If non-zero, last token to include */
-  const char *zOpen;  /* Opening highlight */
-  const char *zClose; /* Closing highlight */
-  const char *zIn;    /* Input text */
-  int nIn;            /* Size of input text in bytes */
-  int iOff;           /* Current offset within zIn[] */
-  char *zOut;         /* Output value */
+    CInstIter iter;     /* Coalesced Instance Iterator */
+    int iPos;           /* Current token offset in zIn[] */
+    int iRangeStart;    /* First token to include */
+    int iRangeEnd;      /* If non-zero, last token to include */
+    const char* zOpen;  /* Opening highlight */
+    const char* zClose; /* Closing highlight */
+    const char* zIn;    /* Input text */
+    int nIn;            /* Size of input text in bytes */
+    int iOff;           /* Current offset within zIn[] */
+    char* zOut;         /* Output value */
 };
 
 /*
@@ -140,108 +146,120 @@ struct HighlightContext {
 ** called, it is a no-op. If an error (i.e. an OOM condition) is encountered,
 ** *pRc is set to an error code before returning.
 */
-static void fts5HighlightAppend(int *pRc, HighlightContext *p, const char *z, int n) {
-  if (*pRc == SQLITE_OK && z) {
-    if (n < 0) n = (int)strlen(z);
-    p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
-    if (p->zOut == 0) *pRc = SQLITE_NOMEM;
-  }
+static void fts5HighlightAppend(int* pRc,
+                                HighlightContext* p,
+                                const char* z,
+                                int n) {
+    if (*pRc == SQLITE_OK && z) {
+        if (n < 0)
+            n = (int)strlen(z);
+        p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
+        if (p->zOut == 0)
+            *pRc = SQLITE_NOMEM;
+    }
 }
 
 /*
 ** Tokenizer callback used by implementation of highlight() function.
 */
-static int fts5HighlightCb(void *pContext,     /* Pointer to HighlightContext object */
-                           int tflags,         /* Mask of FTS5_TOKEN_* flags */
-                           const char *pToken, /* Buffer containing token */
-                           int nToken,         /* Size of token in bytes */
-                           int iStartOff,      /* Start offset of token */
-                           int iEndOff         /* End offset of token */
+static int fts5HighlightCb(
+    void* pContext,     /* Pointer to HighlightContext object */
+    int tflags,         /* Mask of FTS5_TOKEN_* flags */
+    const char* pToken, /* Buffer containing token */
+    int nToken,         /* Size of token in bytes */
+    int iStartOff,      /* Start offset of token */
+    int iEndOff         /* End offset of token */
 ) {
-  HighlightContext *p = (HighlightContext *)pContext;
-  int rc = SQLITE_OK;
-  int iPos;
+    HighlightContext* p = (HighlightContext*)pContext;
+    int rc = SQLITE_OK;
+    int iPos;
 
-  if (tflags & FTS5_TOKEN_COLOCATED) return SQLITE_OK;
-  iPos = p->iPos++;
+    if (tflags & FTS5_TOKEN_COLOCATED)
+        return SQLITE_OK;
+    iPos = p->iPos++;
 
-  if (p->iRangeEnd > 0) {
-    if (iPos < p->iRangeStart || iPos > p->iRangeEnd) return SQLITE_OK;
-    if (p->iRangeStart && iPos == p->iRangeStart) p->iOff = iStartOff;
-  }
-
-  if (iPos == p->iter.iStart) {
-    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iStartOff - p->iOff);
-    fts5HighlightAppend(&rc, p, p->zOpen, -1);
-    p->iOff = iStartOff;
-  }
-
-  if (iPos == p->iter.iEnd) {
-    if (p->iRangeEnd && p->iter.iStart < p->iRangeStart) {
-      fts5HighlightAppend(&rc, p, p->zOpen, -1);
+    if (p->iRangeEnd > 0) {
+        if (iPos < p->iRangeStart || iPos > p->iRangeEnd)
+            return SQLITE_OK;
+        if (p->iRangeStart && iPos == p->iRangeStart)
+            p->iOff = iStartOff;
     }
-    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
-    fts5HighlightAppend(&rc, p, p->zClose, -1);
-    p->iOff = iEndOff;
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterNext(&p->iter);
-    }
-  }
 
-  if (p->iRangeEnd > 0 && iPos == p->iRangeEnd) {
-    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
-    p->iOff = iEndOff;
-    if (iPos >= p->iter.iStart && iPos < p->iter.iEnd) {
-      fts5HighlightAppend(&rc, p, p->zClose, -1);
+    if (iPos == p->iter.iStart) {
+        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iStartOff - p->iOff);
+        fts5HighlightAppend(&rc, p, p->zOpen, -1);
+        p->iOff = iStartOff;
     }
-  }
 
-  return rc;
+    if (iPos == p->iter.iEnd) {
+        if (p->iRangeEnd && p->iter.iStart < p->iRangeStart) {
+            fts5HighlightAppend(&rc, p, p->zOpen, -1);
+        }
+        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
+        fts5HighlightAppend(&rc, p, p->zClose, -1);
+        p->iOff = iEndOff;
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterNext(&p->iter);
+        }
+    }
+
+    if (p->iRangeEnd > 0 && iPos == p->iRangeEnd) {
+        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
+        p->iOff = iEndOff;
+        if (iPos >= p->iter.iStart && iPos < p->iter.iEnd) {
+            fts5HighlightAppend(&rc, p, p->zClose, -1);
+        }
+    }
+
+    return rc;
 }
 
 /*
 ** Implementation of simple_highlight() function.
 */
-void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                      Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                      sqlite3_context *pCtx,        /* Context for returning result/error */
-                      int nVal,                     /* Number of values in apVal[] array */
-                      sqlite3_value **apVal         /* Array of trailing arguments */
+void simple_highlight(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    sqlite3_context* pCtx,        /* Context for returning result/error */
+    int nVal,                     /* Number of values in apVal[] array */
+    sqlite3_value** apVal         /* Array of trailing arguments */
 ) {
-  HighlightContext ctx;
-  int rc;
-  int iCol;
+    HighlightContext ctx;
+    int rc;
+    int iCol;
 
-  if (nVal != 3) {
-    const char *zErr = "wrong number of arguments to function highlight()";
-    sqlite3_result_error(pCtx, zErr, -1);
-    return;
-  }
-
-  iCol = sqlite3_value_int(apVal[0]);
-  memset(&ctx, 0, sizeof(HighlightContext));
-  ctx.zOpen = (const char *)sqlite3_value_text(apVal[1]);
-  ctx.zClose = (const char *)sqlite3_value_text(apVal[2]);
-  rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
-
-  if (ctx.zIn) {
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+    if (nVal != 3) {
+        const char* zErr = "wrong number of arguments to function highlight()";
+        sqlite3_result_error(pCtx, zErr, -1);
+        return;
     }
 
-    if (rc == SQLITE_OK) {
-      rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void *)&ctx, fts5HighlightCb);
-    }
-    fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+    iCol = sqlite3_value_int(apVal[0]);
+    memset(&ctx, 0, sizeof(HighlightContext));
+    ctx.zOpen = (const char*)sqlite3_value_text(apVal[1]);
+    ctx.zClose = (const char*)sqlite3_value_text(apVal[2]);
+    rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
 
-    if (rc == SQLITE_OK) {
-      sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
+    if (ctx.zIn) {
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+        }
+
+        if (rc == SQLITE_OK) {
+            rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void*)&ctx,
+                                 fts5HighlightCb);
+        }
+        fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+
+        if (rc == SQLITE_OK) {
+            sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1,
+                                SQLITE_TRANSIENT);
+        }
+        sqlite3_free(ctx.zOut);
     }
-    sqlite3_free(ctx.zOut);
-  }
-  if (rc != SQLITE_OK) {
-    sqlite3_result_error_code(pCtx, rc);
-  }
+    if (rc != SQLITE_OK) {
+        sqlite3_result_error_code(pCtx, rc);
+    }
 }
 /*
 ** End of highlight() implementation.
@@ -252,14 +270,14 @@ void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FT
 */
 typedef struct HighlightPosContext HighlightPosContext;
 struct HighlightPosContext {
-  CInstIter iter;  /* Coalesced Instance Iterator */
-  int iPos;        /* Current token offset in zIn[] */
-  int iRangeStart; /* First token to include */
-  int iRangeEnd;   /* If non-zero, last token to include */
-  const char *zIn; /* Input text */
-  int nIn;         /* Size of input text in bytes */
-  int iOff;        /* Current offset within zIn[] */
-  char *zOut;      /* Output value */
+    CInstIter iter;  /* Coalesced Instance Iterator */
+    int iPos;        /* Current token offset in zIn[] */
+    int iRangeStart; /* First token to include */
+    int iRangeEnd;   /* If non-zero, last token to include */
+    const char* zIn; /* Input text */
+    int nIn;         /* Size of input text in bytes */
+    int iOff;        /* Current offset within zIn[] */
+    char* zOut;      /* Output value */
 };
 
 /*
@@ -271,74 +289,86 @@ struct HighlightPosContext {
 ** called, it is a no-op. If an error (i.e. an OOM condition) is encountered,
 ** *pRc is set to an error code before returning.
 */
-static void fts5HighlightPosAppend(int *pRc, HighlightPosContext *p, const char *z, int n) {
-  if (*pRc == SQLITE_OK) {
-    if (n < 0) n = (int)strlen(z);
-    p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
-    if (p->zOut == 0) *pRc = SQLITE_NOMEM;
-  }
+static void fts5HighlightPosAppend(int* pRc,
+                                   HighlightPosContext* p,
+                                   const char* z,
+                                   int n) {
+    if (*pRc == SQLITE_OK) {
+        if (n < 0)
+            n = (int)strlen(z);
+        p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
+        if (p->zOut == 0)
+            *pRc = SQLITE_NOMEM;
+    }
 }
 
-static void fts5HighlightPosAppendStart(int *pRc, HighlightPosContext *p, int start) {
-  char str[64];
-  sprintf(str, "%d", start);
-  fts5HighlightPosAppend(pRc, p, str, -1);
-  fts5HighlightPosAppend(pRc, p, ",", -1);
+static void fts5HighlightPosAppendStart(int* pRc,
+                                        HighlightPosContext* p,
+                                        int start) {
+    char str[64];
+    sprintf(str, "%d", start);
+    fts5HighlightPosAppend(pRc, p, str, -1);
+    fts5HighlightPosAppend(pRc, p, ",", -1);
 }
 
-static void fts5HighlightPosAppendEnd(int *pRc, HighlightPosContext *p, int end) {
-  char str[64];
-  sprintf(str, "%d", end);
-  fts5HighlightPosAppend(pRc, p, str, -1);
-  fts5HighlightPosAppend(pRc, p, ";", -1);
+static void fts5HighlightPosAppendEnd(int* pRc,
+                                      HighlightPosContext* p,
+                                      int end) {
+    char str[64];
+    sprintf(str, "%d", end);
+    fts5HighlightPosAppend(pRc, p, str, -1);
+    fts5HighlightPosAppend(pRc, p, ";", -1);
 }
 
 /*
 ** Implementation of simple_highlight_pos() function.
 */
-void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                          Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                          sqlite3_context *pCtx,        /* Context for returning result/error */
-                          int nVal,                     /* Number of values in apVal[] array */
-                          sqlite3_value **apVal         /* Array of trailing arguments */
+void simple_highlight_pos(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    sqlite3_context* pCtx,        /* Context for returning result/error */
+    int nVal,                     /* Number of values in apVal[] array */
+    sqlite3_value** apVal         /* Array of trailing arguments */
 ) {
-  HighlightPosContext ctx;
-  int rc;
-  int iCol;
+    HighlightPosContext ctx;
+    int rc;
+    int iCol;
 
-  if (nVal != 1) {
-    const char *zErr = "wrong number of arguments to function highlight_pos()";
-    sqlite3_result_error(pCtx, zErr, -1);
-    return;
-  }
-
-  iCol = sqlite3_value_int(apVal[0]);
-  memset(&ctx, 0, sizeof(HighlightPosContext));
-  rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
-
-  if (ctx.zIn) {
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+    if (nVal != 1) {
+        const char* zErr =
+            "wrong number of arguments to function highlight_pos()";
+        sqlite3_result_error(pCtx, zErr, -1);
+        return;
     }
 
-    while (rc == SQLITE_OK) {
-      if (ctx.iter.iStart >= 0 && ctx.iter.iEnd >= 0) {
-        fts5HighlightPosAppendStart(&rc, &ctx, ctx.iter.iStart);
-        fts5HighlightPosAppendEnd(&rc, &ctx, ctx.iter.iEnd + 1);
-        rc = fts5CInstIterNext(&ctx.iter);
-      } else {
-        break;
-      }
-    }
+    iCol = sqlite3_value_int(apVal[0]);
+    memset(&ctx, 0, sizeof(HighlightPosContext));
+    rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
 
-    if (rc == SQLITE_OK) {
-      sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
+    if (ctx.zIn) {
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+        }
+
+        while (rc == SQLITE_OK) {
+            if (ctx.iter.iStart >= 0 && ctx.iter.iEnd >= 0) {
+                fts5HighlightPosAppendStart(&rc, &ctx, ctx.iter.iStart);
+                fts5HighlightPosAppendEnd(&rc, &ctx, ctx.iter.iEnd + 1);
+                rc = fts5CInstIterNext(&ctx.iter);
+            } else {
+                break;
+            }
+        }
+
+        if (rc == SQLITE_OK) {
+            sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1,
+                                SQLITE_TRANSIENT);
+        }
+        sqlite3_free(ctx.zOut);
     }
-    sqlite3_free(ctx.zOut);
-  }
-  if (rc != SQLITE_OK) {
-    sqlite3_result_error_code(pCtx, rc);
-  }
+    if (rc != SQLITE_OK) {
+        sqlite3_result_error_code(pCtx, rc);
+    }
 }
 /*
 ** End of highlight_pos() implementation.
@@ -352,11 +382,11 @@ void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by curren
 */
 typedef struct Fts5SnippetFinder Fts5SnippetFinder;
 struct Fts5SnippetFinder {
-  int iPos;         /* Current token position */
-  int nFirstAlloc;  /* Allocated size of aFirst[] */
-  int nFirst;       /* Number of entries in aFirst[] */
-  int *aFirst;      /* Array of first token in each sentence */
-  const char *zDoc; /* Document being tokenized */
+    int iPos;         /* Current token position */
+    int nFirstAlloc;  /* Allocated size of aFirst[] */
+    int nFirst;       /* Number of entries in aFirst[] */
+    int* aFirst;      /* Array of first token in each sentence */
+    const char* zDoc; /* Document being tokenized */
 };
 
 /*
@@ -364,98 +394,106 @@ struct Fts5SnippetFinder {
 ** necessary. Return SQLITE_OK if successful, or SQLITE_NOMEM if an
 ** error occurs.
 */
-static int fts5SnippetFinderAdd(Fts5SnippetFinder *p, int iAdd) {
-  if (p->nFirstAlloc == p->nFirst) {
-    int nNew = p->nFirstAlloc ? p->nFirstAlloc * 2 : 64;
-    int *aNew;
+static int fts5SnippetFinderAdd(Fts5SnippetFinder* p, int iAdd) {
+    if (p->nFirstAlloc == p->nFirst) {
+        int nNew = p->nFirstAlloc ? p->nFirstAlloc * 2 : 64;
+        int* aNew;
 
-    aNew = (int *)sqlite3_realloc64(p->aFirst, nNew * sizeof(int));
-    if (aNew == 0) return SQLITE_NOMEM;
-    p->aFirst = aNew;
-    p->nFirstAlloc = nNew;
-  }
-  p->aFirst[p->nFirst++] = iAdd;
-  return SQLITE_OK;
+        aNew = (int*)sqlite3_realloc64(p->aFirst, nNew * sizeof(int));
+        if (aNew == 0)
+            return SQLITE_NOMEM;
+        p->aFirst = aNew;
+        p->nFirstAlloc = nNew;
+    }
+    p->aFirst[p->nFirst++] = iAdd;
+    return SQLITE_OK;
 }
 
 /*
-** This function is an xTokenize() callback used by the auxiliary simple_snippet()
+** This function is an xTokenize() callback used by the auxiliary
+*simple_snippet()
 ** function. Its job is to identify tokens that are the first in a sentence.
 ** For each such token, an entry is added to the SFinder.aFirst[] array.
 */
-static int fts5SnippetFinderCb(void *pContext,     /* Pointer to HighlightContext object */
-                               int tflags,         /* Mask of FTS5_TOKEN_* flags */
-                               const char *pToken, /* Buffer containing token */
-                               int nToken,         /* Size of token in bytes */
-                               int iStartOff,      /* Start offset of token */
-                               int iEndOff         /* End offset of token */
+static int fts5SnippetFinderCb(
+    void* pContext,     /* Pointer to HighlightContext object */
+    int tflags,         /* Mask of FTS5_TOKEN_* flags */
+    const char* pToken, /* Buffer containing token */
+    int nToken,         /* Size of token in bytes */
+    int iStartOff,      /* Start offset of token */
+    int iEndOff         /* End offset of token */
 ) {
-  int rc = SQLITE_OK;
+    int rc = SQLITE_OK;
 
-  UNUSED_PARAM2(pToken, nToken);
-  UNUSED_PARAM(iEndOff);
+    UNUSED_PARAM2(pToken, nToken);
+    UNUSED_PARAM(iEndOff);
 
-  if ((tflags & FTS5_TOKEN_COLOCATED) == 0) {
-    Fts5SnippetFinder *p = (Fts5SnippetFinder *)pContext;
-    if (p->iPos > 0) {
-      int i;
-      char c = 0;
-      for (i = iStartOff - 1; i >= 0; i--) {
-        c = p->zDoc[i];
-        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
-      }
-      if (i != iStartOff - 1 && (c == '.' || c == ':')) {
-        rc = fts5SnippetFinderAdd(p, p->iPos);
-      }
-    } else {
-      rc = fts5SnippetFinderAdd(p, 0);
+    if ((tflags & FTS5_TOKEN_COLOCATED) == 0) {
+        Fts5SnippetFinder* p = (Fts5SnippetFinder*)pContext;
+        if (p->iPos > 0) {
+            int i;
+            char c = 0;
+            for (i = iStartOff - 1; i >= 0; i--) {
+                c = p->zDoc[i];
+                if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
+                    break;
+            }
+            if (i != iStartOff - 1 && (c == '.' || c == ':')) {
+                rc = fts5SnippetFinderAdd(p, p->iPos);
+            }
+        } else {
+            rc = fts5SnippetFinderAdd(p, 0);
+        }
+        p->iPos++;
     }
-    p->iPos++;
-  }
-  return rc;
+    return rc;
 }
 
-static int fts5SnippetScore(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                            Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                            int nDocsize,                 /* Size of column in tokens */
-                            unsigned char *aSeen,         /* Array with one element per query phrase */
-                            int iCol,                     /* Column to score */
-                            int iPos,                     /* Starting offset to score */
-                            int nToken,                   /* Max tokens per snippet */
-                            int *pnScore,                 /* OUT: Score */
-                            int *piPos                    /* OUT: Adjusted offset */
+static int fts5SnippetScore(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    int nDocsize,                 /* Size of column in tokens */
+    unsigned char* aSeen,         /* Array with one element per query phrase */
+    int iCol,                     /* Column to score */
+    int iPos,                     /* Starting offset to score */
+    int nToken,                   /* Max tokens per snippet */
+    int* pnScore,                 /* OUT: Score */
+    int* piPos                    /* OUT: Adjusted offset */
 ) {
-  int rc;
-  int i;
-  int ip = 0;
-  int ic = 0;
-  int iOff = 0;
-  int iFirst = -1;
-  int nInst;
-  int nScore = 0;
-  int iLast = 0;
-  sqlite3_int64 iEnd = (sqlite3_int64)iPos + nToken;
+    int rc;
+    int i;
+    int ip = 0;
+    int ic = 0;
+    int iOff = 0;
+    int iFirst = -1;
+    int nInst;
+    int nScore = 0;
+    int iLast = 0;
+    sqlite3_int64 iEnd = (sqlite3_int64)iPos + nToken;
 
-  rc = pApi->xInstCount(pFts, &nInst);
-  for (i = 0; i < nInst && rc == SQLITE_OK; i++) {
-    rc = pApi->xInst(pFts, i, &ip, &ic, &iOff);
-    if (rc == SQLITE_OK && ic == iCol && iOff >= iPos && iOff < iEnd) {
-      nScore += (aSeen[ip] ? 1 : 1000);
-      aSeen[ip] = 1;
-      if (iFirst < 0) iFirst = iOff;
-      iLast = iOff + pApi->xPhraseSize(pFts, ip);
+    rc = pApi->xInstCount(pFts, &nInst);
+    for (i = 0; i < nInst && rc == SQLITE_OK; i++) {
+        rc = pApi->xInst(pFts, i, &ip, &ic, &iOff);
+        if (rc == SQLITE_OK && ic == iCol && iOff >= iPos && iOff < iEnd) {
+            nScore += (aSeen[ip] ? 1 : 1000);
+            aSeen[ip] = 1;
+            if (iFirst < 0)
+                iFirst = iOff;
+            iLast = iOff + pApi->xPhraseSize(pFts, ip);
+        }
     }
-  }
 
-  *pnScore = nScore;
-  if (piPos) {
-    sqlite3_int64 iAdj = iFirst - (nToken - (iLast - iFirst)) / 2;
-    if ((iAdj + nToken) > nDocsize) iAdj = nDocsize - nToken;
-    if (iAdj < 0) iAdj = 0;
-    *piPos = (int)iAdj;
-  }
+    *pnScore = nScore;
+    if (piPos) {
+        sqlite3_int64 iAdj = iFirst - (nToken - (iLast - iFirst)) / 2;
+        if ((iAdj + nToken) > nDocsize)
+            iAdj = nDocsize - nToken;
+        if (iAdj < 0)
+            iAdj = 0;
+        *piPos = (int)iAdj;
+    }
 
-  return rc;
+    return rc;
 }
 
 /*
@@ -463,157 +501,172 @@ static int fts5SnippetScore(const Fts5ExtensionApi *pApi, /* API offered by curr
 ** contains a NULL value, return a pointer to a static string zero
 ** bytes in length instead of a NULL pointer.
 */
-static const char *fts5ValueToText(sqlite3_value *pVal) {
-  const char *zRet = (const char *)sqlite3_value_text(pVal);
-  return zRet ? zRet : "";
+static const char* fts5ValueToText(sqlite3_value* pVal) {
+    const char* zRet = (const char*)sqlite3_value_text(pVal);
+    return zRet ? zRet : "";
 }
 
 /*
 ** Implementation of simple_snippet() function.
 */
-void simple_snippet(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                    Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                    sqlite3_context *pCtx,        /* Context for returning result/error */
-                    int nVal,                     /* Number of values in apVal[] array */
-                    sqlite3_value **apVal         /* Array of trailing arguments */
+void simple_snippet(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    sqlite3_context* pCtx,        /* Context for returning result/error */
+    int nVal,                     /* Number of values in apVal[] array */
+    sqlite3_value** apVal         /* Array of trailing arguments */
 ) {
-  HighlightContext ctx;
-  int rc = SQLITE_OK;        /* Return code */
-  int iCol;                  /* 1st argument to snippet() */
-  const char *zEllips;       /* 4th argument to snippet() */
-  int nToken;                /* 5th argument to snippet() */
-  int nInst = 0;             /* Number of instance matches this row */
-  int i;                     /* Used to iterate through instances */
-  int nPhrase;               /* Number of phrases in query */
-  unsigned char *aSeen;      /* Array of "seen instance" flags */
-  int iBestCol;              /* Column containing best snippet */
-  int iBestStart = 0;        /* First token of best snippet */
-  int nBestScore = 0;        /* Score of best snippet */
-  int nColSize = 0;          /* Total size of iBestCol in tokens */
-  Fts5SnippetFinder sFinder; /* Used to find the beginnings of sentences */
-  int nCol;
+    HighlightContext ctx;
+    int rc = SQLITE_OK;        /* Return code */
+    int iCol;                  /* 1st argument to snippet() */
+    const char* zEllips;       /* 4th argument to snippet() */
+    int nToken;                /* 5th argument to snippet() */
+    int nInst = 0;             /* Number of instance matches this row */
+    int i;                     /* Used to iterate through instances */
+    int nPhrase;               /* Number of phrases in query */
+    unsigned char* aSeen;      /* Array of "seen instance" flags */
+    int iBestCol;              /* Column containing best snippet */
+    int iBestStart = 0;        /* First token of best snippet */
+    int nBestScore = 0;        /* Score of best snippet */
+    int nColSize = 0;          /* Total size of iBestCol in tokens */
+    Fts5SnippetFinder sFinder; /* Used to find the beginnings of sentences */
+    int nCol;
 
-  if (nVal != 5) {
-    const char *zErr = "wrong number of arguments to function snippet()";
-    sqlite3_result_error(pCtx, zErr, -1);
-    return;
-  }
+    if (nVal != 5) {
+        const char* zErr = "wrong number of arguments to function snippet()";
+        sqlite3_result_error(pCtx, zErr, -1);
+        return;
+    }
 
-  nCol = pApi->xColumnCount(pFts);
-  memset(&ctx, 0, sizeof(HighlightContext));
-  iCol = sqlite3_value_int(apVal[0]);
-  ctx.zOpen = fts5ValueToText(apVal[1]);
-  ctx.zClose = fts5ValueToText(apVal[2]);
-  zEllips = fts5ValueToText(apVal[3]);
-  nToken = sqlite3_value_int(apVal[4]);
+    nCol = pApi->xColumnCount(pFts);
+    memset(&ctx, 0, sizeof(HighlightContext));
+    iCol = sqlite3_value_int(apVal[0]);
+    ctx.zOpen = fts5ValueToText(apVal[1]);
+    ctx.zClose = fts5ValueToText(apVal[2]);
+    zEllips = fts5ValueToText(apVal[3]);
+    nToken = sqlite3_value_int(apVal[4]);
 
-  iBestCol = (iCol >= 0 ? iCol : 0);
-  nPhrase = pApi->xPhraseCount(pFts);
-  aSeen = (unsigned char *)sqlite3_malloc(nPhrase);
-  if (aSeen == 0) {
-    rc = SQLITE_NOMEM;
-  }
-  if (rc == SQLITE_OK) {
-    rc = pApi->xInstCount(pFts, &nInst);
-  }
+    iBestCol = (iCol >= 0 ? iCol : 0);
+    nPhrase = pApi->xPhraseCount(pFts);
+    aSeen = (unsigned char*)sqlite3_malloc(nPhrase);
+    if (aSeen == 0) {
+        rc = SQLITE_NOMEM;
+    }
+    if (rc == SQLITE_OK) {
+        rc = pApi->xInstCount(pFts, &nInst);
+    }
 
-  memset(&sFinder, 0, sizeof(Fts5SnippetFinder));
-  for (i = 0; i < nCol; i++) {
-    if (iCol < 0 || iCol == i) {
-      int nDoc;
-      int nDocsize;
-      int ii;
-      sFinder.iPos = 0;
-      sFinder.nFirst = 0;
-      rc = pApi->xColumnText(pFts, i, &sFinder.zDoc, &nDoc);
-      if (rc != SQLITE_OK) break;
-      rc = pApi->xTokenize(pFts, sFinder.zDoc, nDoc, (void *)&sFinder, fts5SnippetFinderCb);
-      if (rc != SQLITE_OK) break;
-      rc = pApi->xColumnSize(pFts, i, &nDocsize);
-      if (rc != SQLITE_OK) break;
+    memset(&sFinder, 0, sizeof(Fts5SnippetFinder));
+    for (i = 0; i < nCol; i++) {
+        if (iCol < 0 || iCol == i) {
+            int nDoc;
+            int nDocsize;
+            int ii;
+            sFinder.iPos = 0;
+            sFinder.nFirst = 0;
+            rc = pApi->xColumnText(pFts, i, &sFinder.zDoc, &nDoc);
+            if (rc != SQLITE_OK)
+                break;
+            rc = pApi->xTokenize(pFts, sFinder.zDoc, nDoc, (void*)&sFinder,
+                                 fts5SnippetFinderCb);
+            if (rc != SQLITE_OK)
+                break;
+            rc = pApi->xColumnSize(pFts, i, &nDocsize);
+            if (rc != SQLITE_OK)
+                break;
 
-      for (ii = 0; rc == SQLITE_OK && ii < nInst; ii++) {
-        int ip, ic, io;
-        int iAdj;
-        int nScore;
-        int jj;
+            for (ii = 0; rc == SQLITE_OK && ii < nInst; ii++) {
+                int ip, ic, io;
+                int iAdj;
+                int nScore;
+                int jj;
 
-        rc = pApi->xInst(pFts, ii, &ip, &ic, &io);
-        if (ic != i) continue;
-        if (io > nDocsize) rc = SQLITE_CORRUPT_VTAB;
-        if (rc != SQLITE_OK) continue;
-        memset(aSeen, 0, nPhrase);
-        rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, io, nToken, &nScore, &iAdj);
-        if (rc == SQLITE_OK && nScore > nBestScore) {
-          nBestScore = nScore;
-          iBestCol = i;
-          iBestStart = iAdj;
-          nColSize = nDocsize;
-        }
+                rc = pApi->xInst(pFts, ii, &ip, &ic, &io);
+                if (ic != i)
+                    continue;
+                if (io > nDocsize)
+                    rc = SQLITE_CORRUPT_VTAB;
+                if (rc != SQLITE_OK)
+                    continue;
+                memset(aSeen, 0, nPhrase);
+                rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, io,
+                                      nToken, &nScore, &iAdj);
+                if (rc == SQLITE_OK && nScore > nBestScore) {
+                    nBestScore = nScore;
+                    iBestCol = i;
+                    iBestStart = iAdj;
+                    nColSize = nDocsize;
+                }
 
-        if (rc == SQLITE_OK && sFinder.nFirst && nDocsize > nToken) {
-          for (jj = 0; jj < (sFinder.nFirst - 1); jj++) {
-            if (sFinder.aFirst[jj + 1] > io) break;
-          }
+                if (rc == SQLITE_OK && sFinder.nFirst && nDocsize > nToken) {
+                    for (jj = 0; jj < (sFinder.nFirst - 1); jj++) {
+                        if (sFinder.aFirst[jj + 1] > io)
+                            break;
+                    }
 
-          if (sFinder.aFirst[jj] < io) {
-            memset(aSeen, 0, nPhrase);
-            rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, sFinder.aFirst[jj], nToken, &nScore, 0);
+                    if (sFinder.aFirst[jj] < io) {
+                        memset(aSeen, 0, nPhrase);
+                        rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i,
+                                              sFinder.aFirst[jj], nToken,
+                                              &nScore, 0);
 
-            nScore += (sFinder.aFirst[jj] == 0 ? 120 : 100);
-            if (rc == SQLITE_OK && nScore > nBestScore) {
-              nBestScore = nScore;
-              iBestCol = i;
-              iBestStart = sFinder.aFirst[jj];
-              nColSize = nDocsize;
+                        nScore += (sFinder.aFirst[jj] == 0 ? 120 : 100);
+                        if (rc == SQLITE_OK && nScore > nBestScore) {
+                            nBestScore = nScore;
+                            iBestCol = i;
+                            iBestStart = sFinder.aFirst[jj];
+                            nColSize = nDocsize;
+                        }
+                    }
+                }
             }
-          }
         }
-      }
-    }
-  }
-
-  if (rc == SQLITE_OK) {
-    rc = pApi->xColumnText(pFts, iBestCol, &ctx.zIn, &ctx.nIn);
-  }
-  if (rc == SQLITE_OK && nColSize == 0) {
-    rc = pApi->xColumnSize(pFts, iBestCol, &nColSize);
-  }
-  if (ctx.zIn) {
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterInit(pApi, pFts, iBestCol, &ctx.iter);
-    }
-
-    ctx.iRangeStart = iBestStart;
-    ctx.iRangeEnd = iBestStart + nToken - 1;
-
-    if (iBestStart > 0) {
-      fts5HighlightAppend(&rc, &ctx, zEllips, -1);
-    }
-
-    /* Advance iterator ctx.iter so that it points to the first coalesced
-    ** phrase instance at or following position iBestStart. */
-    while (ctx.iter.iStart >= 0 && ctx.iter.iStart < iBestStart && rc == SQLITE_OK) {
-      rc = fts5CInstIterNext(&ctx.iter);
     }
 
     if (rc == SQLITE_OK) {
-      rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void *)&ctx, fts5HighlightCb);
+        rc = pApi->xColumnText(pFts, iBestCol, &ctx.zIn, &ctx.nIn);
     }
-    if (ctx.iRangeEnd >= (nColSize - 1)) {
-      fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+    if (rc == SQLITE_OK && nColSize == 0) {
+        rc = pApi->xColumnSize(pFts, iBestCol, &nColSize);
+    }
+    if (ctx.zIn) {
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterInit(pApi, pFts, iBestCol, &ctx.iter);
+        }
+
+        ctx.iRangeStart = iBestStart;
+        ctx.iRangeEnd = iBestStart + nToken - 1;
+
+        if (iBestStart > 0) {
+            fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+        }
+
+        /* Advance iterator ctx.iter so that it points to the first coalesced
+        ** phrase instance at or following position iBestStart. */
+        while (ctx.iter.iStart >= 0 && ctx.iter.iStart < iBestStart &&
+               rc == SQLITE_OK) {
+            rc = fts5CInstIterNext(&ctx.iter);
+        }
+
+        if (rc == SQLITE_OK) {
+            rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void*)&ctx,
+                                 fts5HighlightCb);
+        }
+        if (ctx.iRangeEnd >= (nColSize - 1)) {
+            fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff],
+                                ctx.nIn - ctx.iOff);
+        } else {
+            fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+        }
+    }
+    if (rc == SQLITE_OK) {
+        sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1, SQLITE_TRANSIENT);
     } else {
-      fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+        sqlite3_result_error_code(pCtx, rc);
     }
-  }
-  if (rc == SQLITE_OK) {
-    sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
-  } else {
-    sqlite3_result_error_code(pCtx, rc);
-  }
-  sqlite3_free(ctx.zOut);
-  sqlite3_free(aSeen);
-  sqlite3_free(sFinder.aFirst);
+    sqlite3_free(ctx.zOut);
+    sqlite3_free(aSeen);
+    sqlite3_free(sFinder.aFirst);
 }
 
 /************************************************************************/

--- a/src/simple_highlight.cc
+++ b/src/simple_highlight.cc
@@ -50,74 +50,68 @@ SQLITE_EXTENSION_INIT3
 */
 typedef struct CInstIter CInstIter;
 struct CInstIter {
-    const Fts5ExtensionApi* pApi; /* API offered by current FTS version */
-    Fts5Context* pFts;            /* First arg to pass to pApi functions */
-    int iCol;                     /* Column to search */
-    int iInst;                    /* Next phrase instance index */
-    int nInst;                    /* Total number of phrase instances */
+  const Fts5ExtensionApi *pApi; /* API offered by current FTS version */
+  Fts5Context *pFts;            /* First arg to pass to pApi functions */
+  int iCol;                     /* Column to search */
+  int iInst;                    /* Next phrase instance index */
+  int nInst;                    /* Total number of phrase instances */
 
-    /* Output variables */
-    int iStart; /* First token in coalesced phrase instance */
-    int iEnd;   /* Last token in coalesced phrase instance */
+  /* Output variables */
+  int iStart; /* First token in coalesced phrase instance */
+  int iEnd;   /* Last token in coalesced phrase instance */
 };
 
 /*
 ** Advance the iterator to the next coalesced phrase instance. Return
 ** an SQLite error code if an error occurs, or SQLITE_OK otherwise.
 */
-static int fts5CInstIterNext(CInstIter* pIter) {
-    int rc = SQLITE_OK;
-    pIter->iStart = -1;
-    pIter->iEnd = -1;
+static int fts5CInstIterNext(CInstIter *pIter) {
+  int rc = SQLITE_OK;
+  pIter->iStart = -1;
+  pIter->iEnd = -1;
 
-    while (rc == SQLITE_OK && pIter->iInst < pIter->nInst) {
-        int ip;
-        int ic;
-        int io;
-        rc = pIter->pApi->xInst(pIter->pFts, pIter->iInst, &ip, &ic, &io);
-        if (rc == SQLITE_OK) {
-            if (ic == pIter->iCol) {
-                int iEnd = io - 1 + pIter->pApi->xPhraseSize(pIter->pFts, ip);
-                if (pIter->iStart < 0) {
-                    pIter->iStart = io;
-                    pIter->iEnd = iEnd;
-                } else if (io <=
-                           pIter->iEnd + 1) {  // NOTE: +1 is the only diff with
-                                               // buildin highlight function
-                    if (iEnd > pIter->iEnd)
-                        pIter->iEnd = iEnd;
-                } else {
-                    break;
-                }
-            }
-            pIter->iInst++;
+  while (rc == SQLITE_OK && pIter->iInst < pIter->nInst) {
+    int ip;
+    int ic;
+    int io;
+    rc = pIter->pApi->xInst(pIter->pFts, pIter->iInst, &ip, &ic, &io);
+    if (rc == SQLITE_OK) {
+      if (ic == pIter->iCol) {
+        int iEnd = io - 1 + pIter->pApi->xPhraseSize(pIter->pFts, ip);
+        if (pIter->iStart < 0) {
+          pIter->iStart = io;
+          pIter->iEnd = iEnd;
+        } else if (io <= pIter->iEnd + 1) {  // NOTE: +1 is the only diff with buildin highlight function
+          if (iEnd > pIter->iEnd) pIter->iEnd = iEnd;
+        } else {
+          break;
         }
+      }
+      pIter->iInst++;
     }
+  }
 
-    return rc;
+  return rc;
 }
 
 /*
 ** Initialize the iterator object indicated by the final parameter to
 ** iterate through coalesced phrase instances in column iCol.
 */
-static int fts5CInstIterInit(const Fts5ExtensionApi* pApi,
-                             Fts5Context* pFts,
-                             int iCol,
-                             CInstIter* pIter) {
-    int rc;
+static int fts5CInstIterInit(const Fts5ExtensionApi *pApi, Fts5Context *pFts, int iCol, CInstIter *pIter) {
+  int rc;
 
-    memset(pIter, 0, sizeof(CInstIter));
-    pIter->pApi = pApi;
-    pIter->pFts = pFts;
-    pIter->iCol = iCol;
-    rc = pApi->xInstCount(pFts, &pIter->nInst);
+  memset(pIter, 0, sizeof(CInstIter));
+  pIter->pApi = pApi;
+  pIter->pFts = pFts;
+  pIter->iCol = iCol;
+  rc = pApi->xInstCount(pFts, &pIter->nInst);
 
-    if (rc == SQLITE_OK) {
-        rc = fts5CInstIterNext(pIter);
-    }
+  if (rc == SQLITE_OK) {
+    rc = fts5CInstIterNext(pIter);
+  }
 
-    return rc;
+  return rc;
 }
 
 /*************************************************************************
@@ -125,16 +119,16 @@ static int fts5CInstIterInit(const Fts5ExtensionApi* pApi,
 */
 typedef struct HighlightContext HighlightContext;
 struct HighlightContext {
-    CInstIter iter;     /* Coalesced Instance Iterator */
-    int iPos;           /* Current token offset in zIn[] */
-    int iRangeStart;    /* First token to include */
-    int iRangeEnd;      /* If non-zero, last token to include */
-    const char* zOpen;  /* Opening highlight */
-    const char* zClose; /* Closing highlight */
-    const char* zIn;    /* Input text */
-    int nIn;            /* Size of input text in bytes */
-    int iOff;           /* Current offset within zIn[] */
-    char* zOut;         /* Output value */
+  CInstIter iter;     /* Coalesced Instance Iterator */
+  int iPos;           /* Current token offset in zIn[] */
+  int iRangeStart;    /* First token to include */
+  int iRangeEnd;      /* If non-zero, last token to include */
+  const char *zOpen;  /* Opening highlight */
+  const char *zClose; /* Closing highlight */
+  const char *zIn;    /* Input text */
+  int nIn;            /* Size of input text in bytes */
+  int iOff;           /* Current offset within zIn[] */
+  char *zOut;         /* Output value */
 };
 
 /*
@@ -146,120 +140,108 @@ struct HighlightContext {
 ** called, it is a no-op. If an error (i.e. an OOM condition) is encountered,
 ** *pRc is set to an error code before returning.
 */
-static void fts5HighlightAppend(int* pRc,
-                                HighlightContext* p,
-                                const char* z,
-                                int n) {
-    if (*pRc == SQLITE_OK && z) {
-        if (n < 0)
-            n = (int)strlen(z);
-        p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
-        if (p->zOut == 0)
-            *pRc = SQLITE_NOMEM;
-    }
+static void fts5HighlightAppend(int *pRc, HighlightContext *p, const char *z, int n) {
+  if (*pRc == SQLITE_OK && z) {
+    if (n < 0) n = (int)strlen(z);
+    p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
+    if (p->zOut == 0) *pRc = SQLITE_NOMEM;
+  }
 }
 
 /*
 ** Tokenizer callback used by implementation of highlight() function.
 */
-static int fts5HighlightCb(
-    void* pContext,     /* Pointer to HighlightContext object */
-    int tflags,         /* Mask of FTS5_TOKEN_* flags */
-    const char* pToken, /* Buffer containing token */
-    int nToken,         /* Size of token in bytes */
-    int iStartOff,      /* Start offset of token */
-    int iEndOff         /* End offset of token */
+static int fts5HighlightCb(void *pContext,     /* Pointer to HighlightContext object */
+                           int tflags,         /* Mask of FTS5_TOKEN_* flags */
+                           const char *pToken, /* Buffer containing token */
+                           int nToken,         /* Size of token in bytes */
+                           int iStartOff,      /* Start offset of token */
+                           int iEndOff         /* End offset of token */
 ) {
-    HighlightContext* p = (HighlightContext*)pContext;
-    int rc = SQLITE_OK;
-    int iPos;
+  HighlightContext *p = (HighlightContext *)pContext;
+  int rc = SQLITE_OK;
+  int iPos;
 
-    if (tflags & FTS5_TOKEN_COLOCATED)
-        return SQLITE_OK;
-    iPos = p->iPos++;
+  if (tflags & FTS5_TOKEN_COLOCATED) return SQLITE_OK;
+  iPos = p->iPos++;
 
-    if (p->iRangeEnd > 0) {
-        if (iPos < p->iRangeStart || iPos > p->iRangeEnd)
-            return SQLITE_OK;
-        if (p->iRangeStart && iPos == p->iRangeStart)
-            p->iOff = iStartOff;
+  if (p->iRangeEnd > 0) {
+    if (iPos < p->iRangeStart || iPos > p->iRangeEnd) return SQLITE_OK;
+    if (p->iRangeStart && iPos == p->iRangeStart) p->iOff = iStartOff;
+  }
+
+  if (iPos == p->iter.iStart) {
+    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iStartOff - p->iOff);
+    fts5HighlightAppend(&rc, p, p->zOpen, -1);
+    p->iOff = iStartOff;
+  }
+
+  if (iPos == p->iter.iEnd) {
+    if (p->iRangeEnd && p->iter.iStart < p->iRangeStart) {
+      fts5HighlightAppend(&rc, p, p->zOpen, -1);
     }
-
-    if (iPos == p->iter.iStart) {
-        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iStartOff - p->iOff);
-        fts5HighlightAppend(&rc, p, p->zOpen, -1);
-        p->iOff = iStartOff;
+    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
+    fts5HighlightAppend(&rc, p, p->zClose, -1);
+    p->iOff = iEndOff;
+    if (rc == SQLITE_OK) {
+      rc = fts5CInstIterNext(&p->iter);
     }
+  }
 
-    if (iPos == p->iter.iEnd) {
-        if (p->iRangeEnd && p->iter.iStart < p->iRangeStart) {
-            fts5HighlightAppend(&rc, p, p->zOpen, -1);
-        }
-        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
-        fts5HighlightAppend(&rc, p, p->zClose, -1);
-        p->iOff = iEndOff;
-        if (rc == SQLITE_OK) {
-            rc = fts5CInstIterNext(&p->iter);
-        }
+  if (p->iRangeEnd > 0 && iPos == p->iRangeEnd) {
+    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
+    p->iOff = iEndOff;
+    if (iPos >= p->iter.iStart && iPos < p->iter.iEnd) {
+      fts5HighlightAppend(&rc, p, p->zClose, -1);
     }
+  }
 
-    if (p->iRangeEnd > 0 && iPos == p->iRangeEnd) {
-        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
-        p->iOff = iEndOff;
-        if (iPos >= p->iter.iStart && iPos < p->iter.iEnd) {
-            fts5HighlightAppend(&rc, p, p->zClose, -1);
-        }
-    }
-
-    return rc;
+  return rc;
 }
 
 /*
 ** Implementation of simple_highlight() function.
 */
-void simple_highlight(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context* pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value** apVal         /* Array of trailing arguments */
+void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                      Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                      sqlite3_context *pCtx,        /* Context for returning result/error */
+                      int nVal,                     /* Number of values in apVal[] array */
+                      sqlite3_value **apVal         /* Array of trailing arguments */
 ) {
-    HighlightContext ctx;
-    int rc;
-    int iCol;
+  HighlightContext ctx;
+  int rc;
+  int iCol;
 
-    if (nVal != 3) {
-        const char* zErr = "wrong number of arguments to function highlight()";
-        sqlite3_result_error(pCtx, zErr, -1);
-        return;
+  if (nVal != 3) {
+    const char *zErr = "wrong number of arguments to function highlight()";
+    sqlite3_result_error(pCtx, zErr, -1);
+    return;
+  }
+
+  iCol = sqlite3_value_int(apVal[0]);
+  memset(&ctx, 0, sizeof(HighlightContext));
+  ctx.zOpen = (const char *)sqlite3_value_text(apVal[1]);
+  ctx.zClose = (const char *)sqlite3_value_text(apVal[2]);
+  rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
+
+  if (ctx.zIn) {
+    if (rc == SQLITE_OK) {
+      rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
     }
 
-    iCol = sqlite3_value_int(apVal[0]);
-    memset(&ctx, 0, sizeof(HighlightContext));
-    ctx.zOpen = (const char*)sqlite3_value_text(apVal[1]);
-    ctx.zClose = (const char*)sqlite3_value_text(apVal[2]);
-    rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
-
-    if (ctx.zIn) {
-        if (rc == SQLITE_OK) {
-            rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
-        }
-
-        if (rc == SQLITE_OK) {
-            rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void*)&ctx,
-                                 fts5HighlightCb);
-        }
-        fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
-
-        if (rc == SQLITE_OK) {
-            sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1,
-                                SQLITE_TRANSIENT);
-        }
-        sqlite3_free(ctx.zOut);
+    if (rc == SQLITE_OK) {
+      rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void *)&ctx, fts5HighlightCb);
     }
-    if (rc != SQLITE_OK) {
-        sqlite3_result_error_code(pCtx, rc);
+    fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+
+    if (rc == SQLITE_OK) {
+      sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
     }
+    sqlite3_free(ctx.zOut);
+  }
+  if (rc != SQLITE_OK) {
+    sqlite3_result_error_code(pCtx, rc);
+  }
 }
 /*
 ** End of highlight() implementation.
@@ -270,14 +252,14 @@ void simple_highlight(
 */
 typedef struct HighlightPosContext HighlightPosContext;
 struct HighlightPosContext {
-    CInstIter iter;  /* Coalesced Instance Iterator */
-    int iPos;        /* Current token offset in zIn[] */
-    int iRangeStart; /* First token to include */
-    int iRangeEnd;   /* If non-zero, last token to include */
-    const char* zIn; /* Input text */
-    int nIn;         /* Size of input text in bytes */
-    int iOff;        /* Current offset within zIn[] */
-    char* zOut;      /* Output value */
+  CInstIter iter;  /* Coalesced Instance Iterator */
+  int iPos;        /* Current token offset in zIn[] */
+  int iRangeStart; /* First token to include */
+  int iRangeEnd;   /* If non-zero, last token to include */
+  const char *zIn; /* Input text */
+  int nIn;         /* Size of input text in bytes */
+  int iOff;        /* Current offset within zIn[] */
+  char *zOut;      /* Output value */
 };
 
 /*
@@ -289,86 +271,74 @@ struct HighlightPosContext {
 ** called, it is a no-op. If an error (i.e. an OOM condition) is encountered,
 ** *pRc is set to an error code before returning.
 */
-static void fts5HighlightPosAppend(int* pRc,
-                                   HighlightPosContext* p,
-                                   const char* z,
-                                   int n) {
-    if (*pRc == SQLITE_OK) {
-        if (n < 0)
-            n = (int)strlen(z);
-        p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
-        if (p->zOut == 0)
-            *pRc = SQLITE_NOMEM;
-    }
+static void fts5HighlightPosAppend(int *pRc, HighlightPosContext *p, const char *z, int n) {
+  if (*pRc == SQLITE_OK) {
+    if (n < 0) n = (int)strlen(z);
+    p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
+    if (p->zOut == 0) *pRc = SQLITE_NOMEM;
+  }
 }
 
-static void fts5HighlightPosAppendStart(int* pRc,
-                                        HighlightPosContext* p,
-                                        int start) {
-    char str[64];
-    sprintf(str, "%d", start);
-    fts5HighlightPosAppend(pRc, p, str, -1);
-    fts5HighlightPosAppend(pRc, p, ",", -1);
+static void fts5HighlightPosAppendStart(int *pRc, HighlightPosContext *p, int start) {
+  char str[64];
+  sprintf(str, "%d", start);
+  fts5HighlightPosAppend(pRc, p, str, -1);
+  fts5HighlightPosAppend(pRc, p, ",", -1);
 }
 
-static void fts5HighlightPosAppendEnd(int* pRc,
-                                      HighlightPosContext* p,
-                                      int end) {
-    char str[64];
-    sprintf(str, "%d", end);
-    fts5HighlightPosAppend(pRc, p, str, -1);
-    fts5HighlightPosAppend(pRc, p, ";", -1);
+static void fts5HighlightPosAppendEnd(int *pRc, HighlightPosContext *p, int end) {
+  char str[64];
+  sprintf(str, "%d", end);
+  fts5HighlightPosAppend(pRc, p, str, -1);
+  fts5HighlightPosAppend(pRc, p, ";", -1);
 }
 
 /*
 ** Implementation of simple_highlight_pos() function.
 */
-void simple_highlight_pos(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context* pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value** apVal         /* Array of trailing arguments */
+void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                          Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                          sqlite3_context *pCtx,        /* Context for returning result/error */
+                          int nVal,                     /* Number of values in apVal[] array */
+                          sqlite3_value **apVal         /* Array of trailing arguments */
 ) {
-    HighlightPosContext ctx;
-    int rc;
-    int iCol;
+  HighlightPosContext ctx;
+  int rc;
+  int iCol;
 
-    if (nVal != 1) {
-        const char* zErr =
-            "wrong number of arguments to function highlight_pos()";
-        sqlite3_result_error(pCtx, zErr, -1);
-        return;
+  if (nVal != 1) {
+    const char *zErr = "wrong number of arguments to function highlight_pos()";
+    sqlite3_result_error(pCtx, zErr, -1);
+    return;
+  }
+
+  iCol = sqlite3_value_int(apVal[0]);
+  memset(&ctx, 0, sizeof(HighlightPosContext));
+  rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
+
+  if (ctx.zIn) {
+    if (rc == SQLITE_OK) {
+      rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
     }
 
-    iCol = sqlite3_value_int(apVal[0]);
-    memset(&ctx, 0, sizeof(HighlightPosContext));
-    rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
-
-    if (ctx.zIn) {
-        if (rc == SQLITE_OK) {
-            rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
-        }
-
-        while (rc == SQLITE_OK) {
-            if (ctx.iter.iStart >= 0 && ctx.iter.iEnd >= 0) {
-                fts5HighlightPosAppendStart(&rc, &ctx, ctx.iter.iStart);
-                fts5HighlightPosAppendEnd(&rc, &ctx, ctx.iter.iEnd + 1);
-                rc = fts5CInstIterNext(&ctx.iter);
-            } else {
-                break;
-            }
-        }
-
-        if (rc == SQLITE_OK) {
-            sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1,
-                                SQLITE_TRANSIENT);
-        }
-        sqlite3_free(ctx.zOut);
+    while (rc == SQLITE_OK) {
+      if (ctx.iter.iStart >= 0 && ctx.iter.iEnd >= 0) {
+        fts5HighlightPosAppendStart(&rc, &ctx, ctx.iter.iStart);
+        fts5HighlightPosAppendEnd(&rc, &ctx, ctx.iter.iEnd + 1);
+        rc = fts5CInstIterNext(&ctx.iter);
+      } else {
+        break;
+      }
     }
-    if (rc != SQLITE_OK) {
-        sqlite3_result_error_code(pCtx, rc);
+
+    if (rc == SQLITE_OK) {
+      sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
     }
+    sqlite3_free(ctx.zOut);
+  }
+  if (rc != SQLITE_OK) {
+    sqlite3_result_error_code(pCtx, rc);
+  }
 }
 /*
 ** End of highlight_pos() implementation.
@@ -382,11 +352,11 @@ void simple_highlight_pos(
 */
 typedef struct Fts5SnippetFinder Fts5SnippetFinder;
 struct Fts5SnippetFinder {
-    int iPos;         /* Current token position */
-    int nFirstAlloc;  /* Allocated size of aFirst[] */
-    int nFirst;       /* Number of entries in aFirst[] */
-    int* aFirst;      /* Array of first token in each sentence */
-    const char* zDoc; /* Document being tokenized */
+  int iPos;         /* Current token position */
+  int nFirstAlloc;  /* Allocated size of aFirst[] */
+  int nFirst;       /* Number of entries in aFirst[] */
+  int *aFirst;      /* Array of first token in each sentence */
+  const char *zDoc; /* Document being tokenized */
 };
 
 /*
@@ -394,106 +364,98 @@ struct Fts5SnippetFinder {
 ** necessary. Return SQLITE_OK if successful, or SQLITE_NOMEM if an
 ** error occurs.
 */
-static int fts5SnippetFinderAdd(Fts5SnippetFinder* p, int iAdd) {
-    if (p->nFirstAlloc == p->nFirst) {
-        int nNew = p->nFirstAlloc ? p->nFirstAlloc * 2 : 64;
-        int* aNew;
+static int fts5SnippetFinderAdd(Fts5SnippetFinder *p, int iAdd) {
+  if (p->nFirstAlloc == p->nFirst) {
+    int nNew = p->nFirstAlloc ? p->nFirstAlloc * 2 : 64;
+    int *aNew;
 
-        aNew = (int*)sqlite3_realloc64(p->aFirst, nNew * sizeof(int));
-        if (aNew == 0)
-            return SQLITE_NOMEM;
-        p->aFirst = aNew;
-        p->nFirstAlloc = nNew;
-    }
-    p->aFirst[p->nFirst++] = iAdd;
-    return SQLITE_OK;
+    aNew = (int *)sqlite3_realloc64(p->aFirst, nNew * sizeof(int));
+    if (aNew == 0) return SQLITE_NOMEM;
+    p->aFirst = aNew;
+    p->nFirstAlloc = nNew;
+  }
+  p->aFirst[p->nFirst++] = iAdd;
+  return SQLITE_OK;
 }
 
 /*
-** This function is an xTokenize() callback used by the auxiliary
-*simple_snippet()
+** This function is an xTokenize() callback used by the auxiliary simple_snippet()
 ** function. Its job is to identify tokens that are the first in a sentence.
 ** For each such token, an entry is added to the SFinder.aFirst[] array.
 */
-static int fts5SnippetFinderCb(
-    void* pContext,     /* Pointer to HighlightContext object */
-    int tflags,         /* Mask of FTS5_TOKEN_* flags */
-    const char* pToken, /* Buffer containing token */
-    int nToken,         /* Size of token in bytes */
-    int iStartOff,      /* Start offset of token */
-    int iEndOff         /* End offset of token */
+static int fts5SnippetFinderCb(void *pContext,     /* Pointer to HighlightContext object */
+                               int tflags,         /* Mask of FTS5_TOKEN_* flags */
+                               const char *pToken, /* Buffer containing token */
+                               int nToken,         /* Size of token in bytes */
+                               int iStartOff,      /* Start offset of token */
+                               int iEndOff         /* End offset of token */
 ) {
-    int rc = SQLITE_OK;
+  int rc = SQLITE_OK;
 
-    UNUSED_PARAM2(pToken, nToken);
-    UNUSED_PARAM(iEndOff);
+  UNUSED_PARAM2(pToken, nToken);
+  UNUSED_PARAM(iEndOff);
 
-    if ((tflags & FTS5_TOKEN_COLOCATED) == 0) {
-        Fts5SnippetFinder* p = (Fts5SnippetFinder*)pContext;
-        if (p->iPos > 0) {
-            int i;
-            char c = 0;
-            for (i = iStartOff - 1; i >= 0; i--) {
-                c = p->zDoc[i];
-                if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
-                    break;
-            }
-            if (i != iStartOff - 1 && (c == '.' || c == ':')) {
-                rc = fts5SnippetFinderAdd(p, p->iPos);
-            }
-        } else {
-            rc = fts5SnippetFinderAdd(p, 0);
-        }
-        p->iPos++;
+  if ((tflags & FTS5_TOKEN_COLOCATED) == 0) {
+    Fts5SnippetFinder *p = (Fts5SnippetFinder *)pContext;
+    if (p->iPos > 0) {
+      int i;
+      char c = 0;
+      for (i = iStartOff - 1; i >= 0; i--) {
+        c = p->zDoc[i];
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
+      }
+      if (i != iStartOff - 1 && (c == '.' || c == ':')) {
+        rc = fts5SnippetFinderAdd(p, p->iPos);
+      }
+    } else {
+      rc = fts5SnippetFinderAdd(p, 0);
     }
-    return rc;
+    p->iPos++;
+  }
+  return rc;
 }
 
-static int fts5SnippetScore(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    int nDocsize,                 /* Size of column in tokens */
-    unsigned char* aSeen,         /* Array with one element per query phrase */
-    int iCol,                     /* Column to score */
-    int iPos,                     /* Starting offset to score */
-    int nToken,                   /* Max tokens per snippet */
-    int* pnScore,                 /* OUT: Score */
-    int* piPos                    /* OUT: Adjusted offset */
+static int fts5SnippetScore(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                            Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                            int nDocsize,                 /* Size of column in tokens */
+                            unsigned char *aSeen,         /* Array with one element per query phrase */
+                            int iCol,                     /* Column to score */
+                            int iPos,                     /* Starting offset to score */
+                            int nToken,                   /* Max tokens per snippet */
+                            int *pnScore,                 /* OUT: Score */
+                            int *piPos                    /* OUT: Adjusted offset */
 ) {
-    int rc;
-    int i;
-    int ip = 0;
-    int ic = 0;
-    int iOff = 0;
-    int iFirst = -1;
-    int nInst;
-    int nScore = 0;
-    int iLast = 0;
-    sqlite3_int64 iEnd = (sqlite3_int64)iPos + nToken;
+  int rc;
+  int i;
+  int ip = 0;
+  int ic = 0;
+  int iOff = 0;
+  int iFirst = -1;
+  int nInst;
+  int nScore = 0;
+  int iLast = 0;
+  sqlite3_int64 iEnd = (sqlite3_int64)iPos + nToken;
 
-    rc = pApi->xInstCount(pFts, &nInst);
-    for (i = 0; i < nInst && rc == SQLITE_OK; i++) {
-        rc = pApi->xInst(pFts, i, &ip, &ic, &iOff);
-        if (rc == SQLITE_OK && ic == iCol && iOff >= iPos && iOff < iEnd) {
-            nScore += (aSeen[ip] ? 1 : 1000);
-            aSeen[ip] = 1;
-            if (iFirst < 0)
-                iFirst = iOff;
-            iLast = iOff + pApi->xPhraseSize(pFts, ip);
-        }
+  rc = pApi->xInstCount(pFts, &nInst);
+  for (i = 0; i < nInst && rc == SQLITE_OK; i++) {
+    rc = pApi->xInst(pFts, i, &ip, &ic, &iOff);
+    if (rc == SQLITE_OK && ic == iCol && iOff >= iPos && iOff < iEnd) {
+      nScore += (aSeen[ip] ? 1 : 1000);
+      aSeen[ip] = 1;
+      if (iFirst < 0) iFirst = iOff;
+      iLast = iOff + pApi->xPhraseSize(pFts, ip);
     }
+  }
 
-    *pnScore = nScore;
-    if (piPos) {
-        sqlite3_int64 iAdj = iFirst - (nToken - (iLast - iFirst)) / 2;
-        if ((iAdj + nToken) > nDocsize)
-            iAdj = nDocsize - nToken;
-        if (iAdj < 0)
-            iAdj = 0;
-        *piPos = (int)iAdj;
-    }
+  *pnScore = nScore;
+  if (piPos) {
+    sqlite3_int64 iAdj = iFirst - (nToken - (iLast - iFirst)) / 2;
+    if ((iAdj + nToken) > nDocsize) iAdj = nDocsize - nToken;
+    if (iAdj < 0) iAdj = 0;
+    *piPos = (int)iAdj;
+  }
 
-    return rc;
+  return rc;
 }
 
 /*
@@ -501,172 +463,157 @@ static int fts5SnippetScore(
 ** contains a NULL value, return a pointer to a static string zero
 ** bytes in length instead of a NULL pointer.
 */
-static const char* fts5ValueToText(sqlite3_value* pVal) {
-    const char* zRet = (const char*)sqlite3_value_text(pVal);
-    return zRet ? zRet : "";
+static const char *fts5ValueToText(sqlite3_value *pVal) {
+  const char *zRet = (const char *)sqlite3_value_text(pVal);
+  return zRet ? zRet : "";
 }
 
 /*
 ** Implementation of simple_snippet() function.
 */
-void simple_snippet(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context* pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value** apVal         /* Array of trailing arguments */
+void simple_snippet(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                    Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                    sqlite3_context *pCtx,        /* Context for returning result/error */
+                    int nVal,                     /* Number of values in apVal[] array */
+                    sqlite3_value **apVal         /* Array of trailing arguments */
 ) {
-    HighlightContext ctx;
-    int rc = SQLITE_OK;        /* Return code */
-    int iCol;                  /* 1st argument to snippet() */
-    const char* zEllips;       /* 4th argument to snippet() */
-    int nToken;                /* 5th argument to snippet() */
-    int nInst = 0;             /* Number of instance matches this row */
-    int i;                     /* Used to iterate through instances */
-    int nPhrase;               /* Number of phrases in query */
-    unsigned char* aSeen;      /* Array of "seen instance" flags */
-    int iBestCol;              /* Column containing best snippet */
-    int iBestStart = 0;        /* First token of best snippet */
-    int nBestScore = 0;        /* Score of best snippet */
-    int nColSize = 0;          /* Total size of iBestCol in tokens */
-    Fts5SnippetFinder sFinder; /* Used to find the beginnings of sentences */
-    int nCol;
+  HighlightContext ctx;
+  int rc = SQLITE_OK;        /* Return code */
+  int iCol;                  /* 1st argument to snippet() */
+  const char *zEllips;       /* 4th argument to snippet() */
+  int nToken;                /* 5th argument to snippet() */
+  int nInst = 0;             /* Number of instance matches this row */
+  int i;                     /* Used to iterate through instances */
+  int nPhrase;               /* Number of phrases in query */
+  unsigned char *aSeen;      /* Array of "seen instance" flags */
+  int iBestCol;              /* Column containing best snippet */
+  int iBestStart = 0;        /* First token of best snippet */
+  int nBestScore = 0;        /* Score of best snippet */
+  int nColSize = 0;          /* Total size of iBestCol in tokens */
+  Fts5SnippetFinder sFinder; /* Used to find the beginnings of sentences */
+  int nCol;
 
-    if (nVal != 5) {
-        const char* zErr = "wrong number of arguments to function snippet()";
-        sqlite3_result_error(pCtx, zErr, -1);
-        return;
-    }
+  if (nVal != 5) {
+    const char *zErr = "wrong number of arguments to function snippet()";
+    sqlite3_result_error(pCtx, zErr, -1);
+    return;
+  }
 
-    nCol = pApi->xColumnCount(pFts);
-    memset(&ctx, 0, sizeof(HighlightContext));
-    iCol = sqlite3_value_int(apVal[0]);
-    ctx.zOpen = fts5ValueToText(apVal[1]);
-    ctx.zClose = fts5ValueToText(apVal[2]);
-    zEllips = fts5ValueToText(apVal[3]);
-    nToken = sqlite3_value_int(apVal[4]);
+  nCol = pApi->xColumnCount(pFts);
+  memset(&ctx, 0, sizeof(HighlightContext));
+  iCol = sqlite3_value_int(apVal[0]);
+  ctx.zOpen = fts5ValueToText(apVal[1]);
+  ctx.zClose = fts5ValueToText(apVal[2]);
+  zEllips = fts5ValueToText(apVal[3]);
+  nToken = sqlite3_value_int(apVal[4]);
 
-    iBestCol = (iCol >= 0 ? iCol : 0);
-    nPhrase = pApi->xPhraseCount(pFts);
-    aSeen = (unsigned char*)sqlite3_malloc(nPhrase);
-    if (aSeen == 0) {
-        rc = SQLITE_NOMEM;
-    }
-    if (rc == SQLITE_OK) {
-        rc = pApi->xInstCount(pFts, &nInst);
-    }
+  iBestCol = (iCol >= 0 ? iCol : 0);
+  nPhrase = pApi->xPhraseCount(pFts);
+  aSeen = (unsigned char *)sqlite3_malloc(nPhrase);
+  if (aSeen == 0) {
+    rc = SQLITE_NOMEM;
+  }
+  if (rc == SQLITE_OK) {
+    rc = pApi->xInstCount(pFts, &nInst);
+  }
 
-    memset(&sFinder, 0, sizeof(Fts5SnippetFinder));
-    for (i = 0; i < nCol; i++) {
-        if (iCol < 0 || iCol == i) {
-            int nDoc;
-            int nDocsize;
-            int ii;
-            sFinder.iPos = 0;
-            sFinder.nFirst = 0;
-            rc = pApi->xColumnText(pFts, i, &sFinder.zDoc, &nDoc);
-            if (rc != SQLITE_OK)
-                break;
-            rc = pApi->xTokenize(pFts, sFinder.zDoc, nDoc, (void*)&sFinder,
-                                 fts5SnippetFinderCb);
-            if (rc != SQLITE_OK)
-                break;
-            rc = pApi->xColumnSize(pFts, i, &nDocsize);
-            if (rc != SQLITE_OK)
-                break;
+  memset(&sFinder, 0, sizeof(Fts5SnippetFinder));
+  for (i = 0; i < nCol; i++) {
+    if (iCol < 0 || iCol == i) {
+      int nDoc;
+      int nDocsize;
+      int ii;
+      sFinder.iPos = 0;
+      sFinder.nFirst = 0;
+      rc = pApi->xColumnText(pFts, i, &sFinder.zDoc, &nDoc);
+      if (rc != SQLITE_OK) break;
+      rc = pApi->xTokenize(pFts, sFinder.zDoc, nDoc, (void *)&sFinder, fts5SnippetFinderCb);
+      if (rc != SQLITE_OK) break;
+      rc = pApi->xColumnSize(pFts, i, &nDocsize);
+      if (rc != SQLITE_OK) break;
 
-            for (ii = 0; rc == SQLITE_OK && ii < nInst; ii++) {
-                int ip, ic, io;
-                int iAdj;
-                int nScore;
-                int jj;
+      for (ii = 0; rc == SQLITE_OK && ii < nInst; ii++) {
+        int ip, ic, io;
+        int iAdj;
+        int nScore;
+        int jj;
 
-                rc = pApi->xInst(pFts, ii, &ip, &ic, &io);
-                if (ic != i)
-                    continue;
-                if (io > nDocsize)
-                    rc = SQLITE_CORRUPT_VTAB;
-                if (rc != SQLITE_OK)
-                    continue;
-                memset(aSeen, 0, nPhrase);
-                rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, io,
-                                      nToken, &nScore, &iAdj);
-                if (rc == SQLITE_OK && nScore > nBestScore) {
-                    nBestScore = nScore;
-                    iBestCol = i;
-                    iBestStart = iAdj;
-                    nColSize = nDocsize;
-                }
+        rc = pApi->xInst(pFts, ii, &ip, &ic, &io);
+        if (ic != i) continue;
+        if (io > nDocsize) rc = SQLITE_CORRUPT_VTAB;
+        if (rc != SQLITE_OK) continue;
+        memset(aSeen, 0, nPhrase);
+        rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, io, nToken, &nScore, &iAdj);
+        if (rc == SQLITE_OK && nScore > nBestScore) {
+          nBestScore = nScore;
+          iBestCol = i;
+          iBestStart = iAdj;
+          nColSize = nDocsize;
+        }
 
-                if (rc == SQLITE_OK && sFinder.nFirst && nDocsize > nToken) {
-                    for (jj = 0; jj < (sFinder.nFirst - 1); jj++) {
-                        if (sFinder.aFirst[jj + 1] > io)
-                            break;
-                    }
+        if (rc == SQLITE_OK && sFinder.nFirst && nDocsize > nToken) {
+          for (jj = 0; jj < (sFinder.nFirst - 1); jj++) {
+            if (sFinder.aFirst[jj + 1] > io) break;
+          }
 
-                    if (sFinder.aFirst[jj] < io) {
-                        memset(aSeen, 0, nPhrase);
-                        rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i,
-                                              sFinder.aFirst[jj], nToken,
-                                              &nScore, 0);
+          if (sFinder.aFirst[jj] < io) {
+            memset(aSeen, 0, nPhrase);
+            rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, sFinder.aFirst[jj], nToken, &nScore, 0);
 
-                        nScore += (sFinder.aFirst[jj] == 0 ? 120 : 100);
-                        if (rc == SQLITE_OK && nScore > nBestScore) {
-                            nBestScore = nScore;
-                            iBestCol = i;
-                            iBestStart = sFinder.aFirst[jj];
-                            nColSize = nDocsize;
-                        }
-                    }
-                }
+            nScore += (sFinder.aFirst[jj] == 0 ? 120 : 100);
+            if (rc == SQLITE_OK && nScore > nBestScore) {
+              nBestScore = nScore;
+              iBestCol = i;
+              iBestStart = sFinder.aFirst[jj];
+              nColSize = nDocsize;
             }
+          }
         }
+      }
+    }
+  }
+
+  if (rc == SQLITE_OK) {
+    rc = pApi->xColumnText(pFts, iBestCol, &ctx.zIn, &ctx.nIn);
+  }
+  if (rc == SQLITE_OK && nColSize == 0) {
+    rc = pApi->xColumnSize(pFts, iBestCol, &nColSize);
+  }
+  if (ctx.zIn) {
+    if (rc == SQLITE_OK) {
+      rc = fts5CInstIterInit(pApi, pFts, iBestCol, &ctx.iter);
+    }
+
+    ctx.iRangeStart = iBestStart;
+    ctx.iRangeEnd = iBestStart + nToken - 1;
+
+    if (iBestStart > 0) {
+      fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+    }
+
+    /* Advance iterator ctx.iter so that it points to the first coalesced
+    ** phrase instance at or following position iBestStart. */
+    while (ctx.iter.iStart >= 0 && ctx.iter.iStart < iBestStart && rc == SQLITE_OK) {
+      rc = fts5CInstIterNext(&ctx.iter);
     }
 
     if (rc == SQLITE_OK) {
-        rc = pApi->xColumnText(pFts, iBestCol, &ctx.zIn, &ctx.nIn);
+      rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void *)&ctx, fts5HighlightCb);
     }
-    if (rc == SQLITE_OK && nColSize == 0) {
-        rc = pApi->xColumnSize(pFts, iBestCol, &nColSize);
-    }
-    if (ctx.zIn) {
-        if (rc == SQLITE_OK) {
-            rc = fts5CInstIterInit(pApi, pFts, iBestCol, &ctx.iter);
-        }
-
-        ctx.iRangeStart = iBestStart;
-        ctx.iRangeEnd = iBestStart + nToken - 1;
-
-        if (iBestStart > 0) {
-            fts5HighlightAppend(&rc, &ctx, zEllips, -1);
-        }
-
-        /* Advance iterator ctx.iter so that it points to the first coalesced
-        ** phrase instance at or following position iBestStart. */
-        while (ctx.iter.iStart >= 0 && ctx.iter.iStart < iBestStart &&
-               rc == SQLITE_OK) {
-            rc = fts5CInstIterNext(&ctx.iter);
-        }
-
-        if (rc == SQLITE_OK) {
-            rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void*)&ctx,
-                                 fts5HighlightCb);
-        }
-        if (ctx.iRangeEnd >= (nColSize - 1)) {
-            fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff],
-                                ctx.nIn - ctx.iOff);
-        } else {
-            fts5HighlightAppend(&rc, &ctx, zEllips, -1);
-        }
-    }
-    if (rc == SQLITE_OK) {
-        sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1, SQLITE_TRANSIENT);
+    if (ctx.iRangeEnd >= (nColSize - 1)) {
+      fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
     } else {
-        sqlite3_result_error_code(pCtx, rc);
+      fts5HighlightAppend(&rc, &ctx, zEllips, -1);
     }
-    sqlite3_free(ctx.zOut);
-    sqlite3_free(aSeen);
-    sqlite3_free(sFinder.aFirst);
+  }
+  if (rc == SQLITE_OK) {
+    sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
+  } else {
+    sqlite3_result_error_code(pCtx, rc);
+  }
+  sqlite3_free(ctx.zOut);
+  sqlite3_free(aSeen);
+  sqlite3_free(sFinder.aFirst);
 }
 
 /************************************************************************/

--- a/src/simple_highlight.cc
+++ b/src/simple_highlight.cc
@@ -13,7 +13,6 @@
 */
 
 #include "simple_highlight.h"
-
 #include <math.h> /* amalgamator: keep */
 #include <stdio.h>
 #include <string.h>
@@ -50,68 +49,69 @@ SQLITE_EXTENSION_INIT3
 */
 typedef struct CInstIter CInstIter;
 struct CInstIter {
-  const Fts5ExtensionApi *pApi; /* API offered by current FTS version */
-  Fts5Context *pFts;            /* First arg to pass to pApi functions */
-  int iCol;                     /* Column to search */
-  int iInst;                    /* Next phrase instance index */
-  int nInst;                    /* Total number of phrase instances */
+    const Fts5ExtensionApi* pApi; /* API offered by current FTS version */
+    Fts5Context* pFts;            /* First arg to pass to pApi functions */
+    int iCol;                     /* Column to search */
+    int iInst;                    /* Next phrase instance index */
+    int nInst;                    /* Total number of phrase instances */
 
-  /* Output variables */
-  int iStart; /* First token in coalesced phrase instance */
-  int iEnd;   /* Last token in coalesced phrase instance */
+    /* Output variables */
+    int iStart; /* First token in coalesced phrase instance */
+    int iEnd;   /* Last token in coalesced phrase instance */
 };
 
 /*
 ** Advance the iterator to the next coalesced phrase instance. Return
 ** an SQLite error code if an error occurs, or SQLITE_OK otherwise.
 */
-static int fts5CInstIterNext(CInstIter *pIter) {
-  int rc = SQLITE_OK;
-  pIter->iStart = -1;
-  pIter->iEnd = -1;
+static int fts5CInstIterNext(CInstIter* pIter) {
+    int rc = SQLITE_OK;
+    pIter->iStart = -1;
+    pIter->iEnd = -1;
 
-  while (rc == SQLITE_OK && pIter->iInst < pIter->nInst) {
-    int ip;
-    int ic;
-    int io;
-    rc = pIter->pApi->xInst(pIter->pFts, pIter->iInst, &ip, &ic, &io);
-    if (rc == SQLITE_OK) {
-      if (ic == pIter->iCol) {
-        int iEnd = io - 1 + pIter->pApi->xPhraseSize(pIter->pFts, ip);
-        if (pIter->iStart < 0) {
-          pIter->iStart = io;
-          pIter->iEnd = iEnd;
-        } else if (io <= pIter->iEnd + 1) {  // NOTE: +1 is the only diff with buildin highlight function
-          if (iEnd > pIter->iEnd) pIter->iEnd = iEnd;
-        } else {
-          break;
+    while (rc == SQLITE_OK && pIter->iInst < pIter->nInst) {
+        int ip;
+        int ic;
+        int io;
+        rc = pIter->pApi->xInst(pIter->pFts, pIter->iInst, &ip, &ic, &io);
+        if (rc == SQLITE_OK) {
+            if (ic == pIter->iCol) {
+                int iEnd = io - 1 + pIter->pApi->xPhraseSize(pIter->pFts, ip);
+                if (pIter->iStart < 0) {
+                    pIter->iStart = io;
+                    pIter->iEnd = iEnd;
+                } else if (io <= pIter->iEnd + 1) {  // NOTE: +1 is the only diff with buildin highlight function
+                    if (iEnd > pIter->iEnd)
+                        pIter->iEnd = iEnd;
+                } else {
+                    break;
+                }
+            }
+            pIter->iInst++;
         }
-      }
-      pIter->iInst++;
     }
-  }
 
-  return rc;
+    return rc;
 }
 
 /*
 ** Initialize the iterator object indicated by the final parameter to
 ** iterate through coalesced phrase instances in column iCol.
 */
-static int fts5CInstIterInit(const Fts5ExtensionApi *pApi, Fts5Context *pFts, int iCol, CInstIter *pIter) {
-  int rc;
+static int fts5CInstIterInit(const Fts5ExtensionApi* pApi, Fts5Context* pFts, int iCol, CInstIter* pIter) {
+    int rc;
 
-  memset(pIter, 0, sizeof(CInstIter));
-  pIter->pApi = pApi;
-  pIter->pFts = pFts;
-  pIter->iCol = iCol;
-  rc = pApi->xInstCount(pFts, &pIter->nInst);
+    memset(pIter, 0, sizeof(CInstIter));
+    pIter->pApi = pApi;
+    pIter->pFts = pFts;
+    pIter->iCol = iCol;
+    rc = pApi->xInstCount(pFts, &pIter->nInst);
 
-  if (rc == SQLITE_OK) {
-    rc = fts5CInstIterNext(pIter);
-  }
+    if (rc == SQLITE_OK) {
+        rc = fts5CInstIterNext(pIter);
+    }
 
-  return rc;
+    return rc;
 }
 
 /*************************************************************************
@@ -119,16 +119,16 @@ static int fts5CInstIterInit(const Fts5ExtensionApi *pApi, Fts5Context *pFts, in
 */
 typedef struct HighlightContext HighlightContext;
 struct HighlightContext {
-  CInstIter iter;     /* Coalesced Instance Iterator */
-  int iPos;           /* Current token offset in zIn[] */
-  int iRangeStart;    /* First token to include */
-  int iRangeEnd;      /* If non-zero, last token to include */
-  const char *zOpen;  /* Opening highlight */
-  const char *zClose; /* Closing highlight */
-  const char *zIn;    /* Input text */
-  int nIn;            /* Size of input text in bytes */
-  int iOff;           /* Current offset within zIn[] */
-  char *zOut;         /* Output value */
+    CInstIter iter;     /* Coalesced Instance Iterator */
+    int iPos;           /* Current token offset in zIn[] */
+    int iRangeStart;    /* First token to include */
+    int iRangeEnd;      /* If non-zero, last token to include */
+    const char* zOpen;  /* Opening highlight */
+    const char* zClose; /* Closing highlight */
+    const char* zIn;    /* Input text */
+    int nIn;            /* Size of input text in bytes */
+    int iOff;           /* Current offset within zIn[] */
+    char* zOut;         /* Output value */
 };
 
 /*
@@ -140,108 +140,113 @@ struct HighlightContext {
 ** called, it is a no-op. If an error (i.e. an OOM condition) is encountered,
 ** *pRc is set to an error code before returning.
 */
-static void fts5HighlightAppend(int *pRc, HighlightContext *p, const char *z, int n) {
-  if (*pRc == SQLITE_OK && z) {
-    if (n < 0) n = (int)strlen(z);
-    p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
-    if (p->zOut == 0) *pRc = SQLITE_NOMEM;
-  }
+static void fts5HighlightAppend(int* pRc, HighlightContext* p, const char* z, int n) {
+    if (*pRc == SQLITE_OK && z) {
+        if (n < 0)
+            n = (int)strlen(z);
+        p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
+        if (p->zOut == 0)
+            *pRc = SQLITE_NOMEM;
+    }
 }
 
 /*
 ** Tokenizer callback used by implementation of highlight() function.
 */
-static int fts5HighlightCb(void *pContext,     /* Pointer to HighlightContext object */
+static int fts5HighlightCb(void* pContext,     /* Pointer to HighlightContext object */
                            int tflags,         /* Mask of FTS5_TOKEN_* flags */
-                           const char *pToken, /* Buffer containing token */
+                           const char* pToken, /* Buffer containing token */
                            int nToken,         /* Size of token in bytes */
                            int iStartOff,      /* Start offset of token */
                            int iEndOff         /* End offset of token */
 ) {
-  HighlightContext *p = (HighlightContext *)pContext;
-  int rc = SQLITE_OK;
-  int iPos;
+    HighlightContext* p = (HighlightContext*)pContext;
+    int rc = SQLITE_OK;
+    int iPos;
 
-  if (tflags & FTS5_TOKEN_COLOCATED) return SQLITE_OK;
-  iPos = p->iPos++;
+    if (tflags & FTS5_TOKEN_COLOCATED)
+        return SQLITE_OK;
+    iPos = p->iPos++;
 
-  if (p->iRangeEnd > 0) {
-    if (iPos < p->iRangeStart || iPos > p->iRangeEnd) return SQLITE_OK;
-    if (p->iRangeStart && iPos == p->iRangeStart) p->iOff = iStartOff;
-  }
-
-  if (iPos == p->iter.iStart) {
-    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iStartOff - p->iOff);
-    fts5HighlightAppend(&rc, p, p->zOpen, -1);
-    p->iOff = iStartOff;
-  }
-
-  if (iPos == p->iter.iEnd) {
-    if (p->iRangeEnd && p->iter.iStart < p->iRangeStart) {
-      fts5HighlightAppend(&rc, p, p->zOpen, -1);
+    if (p->iRangeEnd > 0) {
+        if (iPos < p->iRangeStart || iPos > p->iRangeEnd)
+            return SQLITE_OK;
+        if (p->iRangeStart && iPos == p->iRangeStart)
+            p->iOff = iStartOff;
     }
-    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
-    fts5HighlightAppend(&rc, p, p->zClose, -1);
-    p->iOff = iEndOff;
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterNext(&p->iter);
-    }
-  }
 
-  if (p->iRangeEnd > 0 && iPos == p->iRangeEnd) {
-    fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
-    p->iOff = iEndOff;
-    if (iPos >= p->iter.iStart && iPos < p->iter.iEnd) {
-      fts5HighlightAppend(&rc, p, p->zClose, -1);
+    if (iPos == p->iter.iStart) {
+        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iStartOff - p->iOff);
+        fts5HighlightAppend(&rc, p, p->zOpen, -1);
+        p->iOff = iStartOff;
     }
-  }
 
-  return rc;
+    if (iPos == p->iter.iEnd) {
+        if (p->iRangeEnd && p->iter.iStart < p->iRangeStart) {
+            fts5HighlightAppend(&rc, p, p->zOpen, -1);
+        }
+        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
+        fts5HighlightAppend(&rc, p, p->zClose, -1);
+        p->iOff = iEndOff;
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterNext(&p->iter);
+        }
+    }
+
+    if (p->iRangeEnd > 0 && iPos == p->iRangeEnd) {
+        fts5HighlightAppend(&rc, p, &p->zIn[p->iOff], iEndOff - p->iOff);
+        p->iOff = iEndOff;
+        if (iPos >= p->iter.iStart && iPos < p->iter.iEnd) {
+            fts5HighlightAppend(&rc, p, p->zClose, -1);
+        }
+    }
+
+    return rc;
 }
 
 /*
 ** Implementation of simple_highlight() function.
 */
-void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                      Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                      sqlite3_context *pCtx,        /* Context for returning result/error */
+void simple_highlight(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                      Fts5Context* pFts,            /* First arg to pass to pApi functions */
+                      sqlite3_context* pCtx,        /* Context for returning result/error */
                       int nVal,                     /* Number of values in apVal[] array */
-                      sqlite3_value **apVal         /* Array of trailing arguments */
+                      sqlite3_value** apVal         /* Array of trailing arguments */
 ) {
-  HighlightContext ctx;
-  int rc;
-  int iCol;
+    HighlightContext ctx;
+    int rc;
+    int iCol;
 
-  if (nVal != 3) {
-    const char *zErr = "wrong number of arguments to function highlight()";
-    sqlite3_result_error(pCtx, zErr, -1);
-    return;
-  }
-
-  iCol = sqlite3_value_int(apVal[0]);
-  memset(&ctx, 0, sizeof(HighlightContext));
-  ctx.zOpen = (const char *)sqlite3_value_text(apVal[1]);
-  ctx.zClose = (const char *)sqlite3_value_text(apVal[2]);
-  rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
-
-  if (ctx.zIn) {
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+    if (nVal != 3) {
+        const char* zErr = "wrong number of arguments to function highlight()";
+        sqlite3_result_error(pCtx, zErr, -1);
+        return;
     }
 
-    if (rc == SQLITE_OK) {
-      rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void *)&ctx, fts5HighlightCb);
-    }
-    fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+    iCol = sqlite3_value_int(apVal[0]);
+    memset(&ctx, 0, sizeof(HighlightContext));
+    ctx.zOpen = (const char*)sqlite3_value_text(apVal[1]);
+    ctx.zClose = (const char*)sqlite3_value_text(apVal[2]);
+    rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
 
-    if (rc == SQLITE_OK) {
-      sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
+    if (ctx.zIn) {
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+        }
+
+        if (rc == SQLITE_OK) {
+            rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void*)&ctx, fts5HighlightCb);
+        }
+        fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+
+        if (rc == SQLITE_OK) {
+            sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1, SQLITE_TRANSIENT);
+        }
+        sqlite3_free(ctx.zOut);
     }
-    sqlite3_free(ctx.zOut);
-  }
-  if (rc != SQLITE_OK) {
-    sqlite3_result_error_code(pCtx, rc);
-  }
+    if (rc != SQLITE_OK) {
+        sqlite3_result_error_code(pCtx, rc);
+    }
 }
 /*
 ** End of highlight() implementation.
@@ -252,14 +257,14 @@ void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FT
 */
 typedef struct HighlightPosContext HighlightPosContext;
 struct HighlightPosContext {
-  CInstIter iter;  /* Coalesced Instance Iterator */
-  int iPos;        /* Current token offset in zIn[] */
-  int iRangeStart; /* First token to include */
-  int iRangeEnd;   /* If non-zero, last token to include */
-  const char *zIn; /* Input text */
-  int nIn;         /* Size of input text in bytes */
-  int iOff;        /* Current offset within zIn[] */
-  char *zOut;      /* Output value */
+    CInstIter iter;  /* Coalesced Instance Iterator */
+    int iPos;        /* Current token offset in zIn[] */
+    int iRangeStart; /* First token to include */
+    int iRangeEnd;   /* If non-zero, last token to include */
+    const char* zIn; /* Input text */
+    int nIn;         /* Size of input text in bytes */
+    int iOff;        /* Current offset within zIn[] */
+    char* zOut;      /* Output value */
 };
 
 /*
@@ -271,74 +276,76 @@ struct HighlightPosContext {
 ** called, it is a no-op. If an error (i.e. an OOM condition) is encountered,
 ** *pRc is set to an error code before returning.
 */
-static void fts5HighlightPosAppend(int *pRc, HighlightPosContext *p, const char *z, int n) {
-  if (*pRc == SQLITE_OK) {
-    if (n < 0) n = (int)strlen(z);
-    p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
-    if (p->zOut == 0) *pRc = SQLITE_NOMEM;
-  }
+static void fts5HighlightPosAppend(int* pRc, HighlightPosContext* p, const char* z, int n) {
+    if (*pRc == SQLITE_OK) {
+        if (n < 0)
+            n = (int)strlen(z);
+        p->zOut = sqlite3_mprintf("%z%.*s", p->zOut, n, z);
+        if (p->zOut == 0)
+            *pRc = SQLITE_NOMEM;
+    }
 }
 
-static void fts5HighlightPosAppendStart(int *pRc, HighlightPosContext *p, int start) {
-  char str[64];
-  sprintf(str, "%d", start);
-  fts5HighlightPosAppend(pRc, p, str, -1);
-  fts5HighlightPosAppend(pRc, p, ",", -1);
+static void fts5HighlightPosAppendStart(int* pRc, HighlightPosContext* p, int start) {
+    char str[64];
+    sprintf(str, "%d", start);
+    fts5HighlightPosAppend(pRc, p, str, -1);
+    fts5HighlightPosAppend(pRc, p, ",", -1);
 }
 
-static void fts5HighlightPosAppendEnd(int *pRc, HighlightPosContext *p, int end) {
-  char str[64];
-  sprintf(str, "%d", end);
-  fts5HighlightPosAppend(pRc, p, str, -1);
-  fts5HighlightPosAppend(pRc, p, ";", -1);
+static void fts5HighlightPosAppendEnd(int* pRc, HighlightPosContext* p, int end) {
+    char str[64];
+    sprintf(str, "%d", end);
+    fts5HighlightPosAppend(pRc, p, str, -1);
+    fts5HighlightPosAppend(pRc, p, ";", -1);
 }
 
 /*
 ** Implementation of simple_highlight_pos() function.
 */
-void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                          Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                          sqlite3_context *pCtx,        /* Context for returning result/error */
+void simple_highlight_pos(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                          Fts5Context* pFts,            /* First arg to pass to pApi functions */
+                          sqlite3_context* pCtx,        /* Context for returning result/error */
                           int nVal,                     /* Number of values in apVal[] array */
-                          sqlite3_value **apVal         /* Array of trailing arguments */
+                          sqlite3_value** apVal         /* Array of trailing arguments */
 ) {
-  HighlightPosContext ctx;
-  int rc;
-  int iCol;
+    HighlightPosContext ctx;
+    int rc;
+    int iCol;
 
-  if (nVal != 1) {
-    const char *zErr = "wrong number of arguments to function highlight_pos()";
-    sqlite3_result_error(pCtx, zErr, -1);
-    return;
-  }
-
-  iCol = sqlite3_value_int(apVal[0]);
-  memset(&ctx, 0, sizeof(HighlightPosContext));
-  rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
-
-  if (ctx.zIn) {
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+    if (nVal != 1) {
+        const char* zErr = "wrong number of arguments to function highlight_pos()";
+        sqlite3_result_error(pCtx, zErr, -1);
+        return;
     }
 
-    while (rc == SQLITE_OK) {
-      if (ctx.iter.iStart >= 0 && ctx.iter.iEnd >= 0) {
-        fts5HighlightPosAppendStart(&rc, &ctx, ctx.iter.iStart);
-        fts5HighlightPosAppendEnd(&rc, &ctx, ctx.iter.iEnd + 1);
-        rc = fts5CInstIterNext(&ctx.iter);
-      } else {
-        break;
-      }
-    }
+    iCol = sqlite3_value_int(apVal[0]);
+    memset(&ctx, 0, sizeof(HighlightPosContext));
+    rc = pApi->xColumnText(pFts, iCol, &ctx.zIn, &ctx.nIn);
 
-    if (rc == SQLITE_OK) {
-      sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
+    if (ctx.zIn) {
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterInit(pApi, pFts, iCol, &ctx.iter);
+        }
+
+        while (rc == SQLITE_OK) {
+            if (ctx.iter.iStart >= 0 && ctx.iter.iEnd >= 0) {
+                fts5HighlightPosAppendStart(&rc, &ctx, ctx.iter.iStart);
+                fts5HighlightPosAppendEnd(&rc, &ctx, ctx.iter.iEnd + 1);
+                rc = fts5CInstIterNext(&ctx.iter);
+            } else {
+                break;
+            }
+        }
+
+        if (rc == SQLITE_OK) {
+            sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1, SQLITE_TRANSIENT);
+        }
+        sqlite3_free(ctx.zOut);
     }
-    sqlite3_free(ctx.zOut);
-  }
-  if (rc != SQLITE_OK) {
-    sqlite3_result_error_code(pCtx, rc);
-  }
+    if (rc != SQLITE_OK) {
+        sqlite3_result_error_code(pCtx, rc);
+    }
 }
 /*
 ** End of highlight_pos() implementation.
@@ -352,11 +359,11 @@ void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by curren
 */
 typedef struct Fts5SnippetFinder Fts5SnippetFinder;
 struct Fts5SnippetFinder {
-  int iPos;         /* Current token position */
-  int nFirstAlloc;  /* Allocated size of aFirst[] */
-  int nFirst;       /* Number of entries in aFirst[] */
-  int *aFirst;      /* Array of first token in each sentence */
-  const char *zDoc; /* Document being tokenized */
+    int iPos;         /* Current token position */
+    int nFirstAlloc;  /* Allocated size of aFirst[] */
+    int nFirst;       /* Number of entries in aFirst[] */
+    int* aFirst;      /* Array of first token in each sentence */
+    const char* zDoc; /* Document being tokenized */
 };
 
 /*
@@ -364,18 +371,19 @@ struct Fts5SnippetFinder {
 ** necessary. Return SQLITE_OK if successful, or SQLITE_NOMEM if an
 ** error occurs.
 */
-static int fts5SnippetFinderAdd(Fts5SnippetFinder *p, int iAdd) {
-  if (p->nFirstAlloc == p->nFirst) {
-    int nNew = p->nFirstAlloc ? p->nFirstAlloc * 2 : 64;
-    int *aNew;
+static int fts5SnippetFinderAdd(Fts5SnippetFinder* p, int iAdd) {
+    if (p->nFirstAlloc == p->nFirst) {
+        int nNew = p->nFirstAlloc ? p->nFirstAlloc * 2 : 64;
+        int* aNew;
 
-    aNew = (int *)sqlite3_realloc64(p->aFirst, nNew * sizeof(int));
-    if (aNew == 0) return SQLITE_NOMEM;
-    p->aFirst = aNew;
-    p->nFirstAlloc = nNew;
-  }
-  p->aFirst[p->nFirst++] = iAdd;
-  return SQLITE_OK;
+        aNew = (int*)sqlite3_realloc64(p->aFirst, nNew * sizeof(int));
+        if (aNew == 0)
+            return SQLITE_NOMEM;
+        p->aFirst = aNew;
+        p->nFirstAlloc = nNew;
+    }
+    p->aFirst[p->nFirst++] = iAdd;
+    return SQLITE_OK;
 }
 
 /*
@@ -383,79 +391,83 @@ static int fts5SnippetFinderAdd(Fts5SnippetFinder *p, int iAdd) {
 ** function. Its job is to identify tokens that are the first in a sentence.
 ** For each such token, an entry is added to the SFinder.aFirst[] array.
 */
-static int fts5SnippetFinderCb(void *pContext,     /* Pointer to HighlightContext object */
+static int fts5SnippetFinderCb(void* pContext,     /* Pointer to HighlightContext object */
                                int tflags,         /* Mask of FTS5_TOKEN_* flags */
-                               const char *pToken, /* Buffer containing token */
+                               const char* pToken, /* Buffer containing token */
                                int nToken,         /* Size of token in bytes */
                                int iStartOff,      /* Start offset of token */
                                int iEndOff         /* End offset of token */
 ) {
-  int rc = SQLITE_OK;
+    int rc = SQLITE_OK;
 
-  UNUSED_PARAM2(pToken, nToken);
-  UNUSED_PARAM(iEndOff);
+    UNUSED_PARAM2(pToken, nToken);
+    UNUSED_PARAM(iEndOff);
 
-  if ((tflags & FTS5_TOKEN_COLOCATED) == 0) {
-    Fts5SnippetFinder *p = (Fts5SnippetFinder *)pContext;
-    if (p->iPos > 0) {
-      int i;
-      char c = 0;
-      for (i = iStartOff - 1; i >= 0; i--) {
-        c = p->zDoc[i];
-        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') break;
-      }
-      if (i != iStartOff - 1 && (c == '.' || c == ':')) {
-        rc = fts5SnippetFinderAdd(p, p->iPos);
-      }
-    } else {
-      rc = fts5SnippetFinderAdd(p, 0);
+    if ((tflags & FTS5_TOKEN_COLOCATED) == 0) {
+        Fts5SnippetFinder* p = (Fts5SnippetFinder*)pContext;
+        if (p->iPos > 0) {
+            int i;
+            char c = 0;
+            for (i = iStartOff - 1; i >= 0; i--) {
+                c = p->zDoc[i];
+                if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
+                    break;
+            }
+            if (i != iStartOff - 1 && (c == '.' || c == ':')) {
+                rc = fts5SnippetFinderAdd(p, p->iPos);
+            }
+        } else {
+            rc = fts5SnippetFinderAdd(p, 0);
+        }
+        p->iPos++;
     }
-    p->iPos++;
-  }
-  return rc;
+    return rc;
 }
 
-static int fts5SnippetScore(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                            Fts5Context *pFts,            /* First arg to pass to pApi functions */
+static int fts5SnippetScore(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                            Fts5Context* pFts,            /* First arg to pass to pApi functions */
                             int nDocsize,                 /* Size of column in tokens */
-                            unsigned char *aSeen,         /* Array with one element per query phrase */
+                            unsigned char* aSeen,         /* Array with one element per query phrase */
                             int iCol,                     /* Column to score */
                             int iPos,                     /* Starting offset to score */
                             int nToken,                   /* Max tokens per snippet */
-                            int *pnScore,                 /* OUT: Score */
-                            int *piPos                    /* OUT: Adjusted offset */
+                            int* pnScore,                 /* OUT: Score */
+                            int* piPos                    /* OUT: Adjusted offset */
 ) {
-  int rc;
-  int i;
-  int ip = 0;
-  int ic = 0;
-  int iOff = 0;
-  int iFirst = -1;
-  int nInst;
-  int nScore = 0;
-  int iLast = 0;
-  sqlite3_int64 iEnd = (sqlite3_int64)iPos + nToken;
+    int rc;
+    int i;
+    int ip = 0;
+    int ic = 0;
+    int iOff = 0;
+    int iFirst = -1;
+    int nInst;
+    int nScore = 0;
+    int iLast = 0;
+    sqlite3_int64 iEnd = (sqlite3_int64)iPos + nToken;
 
-  rc = pApi->xInstCount(pFts, &nInst);
-  for (i = 0; i < nInst && rc == SQLITE_OK; i++) {
-    rc = pApi->xInst(pFts, i, &ip, &ic, &iOff);
-    if (rc == SQLITE_OK && ic == iCol && iOff >= iPos && iOff < iEnd) {
-      nScore += (aSeen[ip] ? 1 : 1000);
-      aSeen[ip] = 1;
-      if (iFirst < 0) iFirst = iOff;
-      iLast = iOff + pApi->xPhraseSize(pFts, ip);
+    rc = pApi->xInstCount(pFts, &nInst);
+    for (i = 0; i < nInst && rc == SQLITE_OK; i++) {
+        rc = pApi->xInst(pFts, i, &ip, &ic, &iOff);
+        if (rc == SQLITE_OK && ic == iCol && iOff >= iPos && iOff < iEnd) {
+            nScore += (aSeen[ip] ? 1 : 1000);
+            aSeen[ip] = 1;
+            if (iFirst < 0)
+                iFirst = iOff;
+            iLast = iOff + pApi->xPhraseSize(pFts, ip);
+        }
     }
-  }
 
-  *pnScore = nScore;
-  if (piPos) {
-    sqlite3_int64 iAdj = iFirst - (nToken - (iLast - iFirst)) / 2;
-    if ((iAdj + nToken) > nDocsize) iAdj = nDocsize - nToken;
-    if (iAdj < 0) iAdj = 0;
-    *piPos = (int)iAdj;
-  }
+    *pnScore = nScore;
+    if (piPos) {
+        sqlite3_int64 iAdj = iFirst - (nToken - (iLast - iFirst)) / 2;
+        if ((iAdj + nToken) > nDocsize)
+            iAdj = nDocsize - nToken;
+        if (iAdj < 0)
+            iAdj = 0;
+        *piPos = (int)iAdj;
+    }
 
-  return rc;
+    return rc;
 }
 
 /*
@@ -463,157 +475,164 @@ static int fts5SnippetScore(const Fts5ExtensionApi *pApi, /* API offered by curr
 ** contains a NULL value, return a pointer to a static string zero
 ** bytes in length instead of a NULL pointer.
 */
-static const char *fts5ValueToText(sqlite3_value *pVal) {
-  const char *zRet = (const char *)sqlite3_value_text(pVal);
-  return zRet ? zRet : "";
+static const char* fts5ValueToText(sqlite3_value* pVal) {
+    const char* zRet = (const char*)sqlite3_value_text(pVal);
+    return zRet ? zRet : "";
 }
 
 /*
 ** Implementation of simple_snippet() function.
 */
-void simple_snippet(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                    Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                    sqlite3_context *pCtx,        /* Context for returning result/error */
+void simple_snippet(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+                    sqlite3_context* pCtx,        /* Context for returning result/error */
                     int nVal,                     /* Number of values in apVal[] array */
-                    sqlite3_value **apVal         /* Array of trailing arguments */
+                    sqlite3_value** apVal         /* Array of trailing arguments */
 ) {
-  HighlightContext ctx;
-  int rc = SQLITE_OK;        /* Return code */
-  int iCol;                  /* 1st argument to snippet() */
-  const char *zEllips;       /* 4th argument to snippet() */
-  int nToken;                /* 5th argument to snippet() */
-  int nInst = 0;             /* Number of instance matches this row */
-  int i;                     /* Used to iterate through instances */
-  int nPhrase;               /* Number of phrases in query */
-  unsigned char *aSeen;      /* Array of "seen instance" flags */
-  int iBestCol;              /* Column containing best snippet */
-  int iBestStart = 0;        /* First token of best snippet */
-  int nBestScore = 0;        /* Score of best snippet */
-  int nColSize = 0;          /* Total size of iBestCol in tokens */
-  Fts5SnippetFinder sFinder; /* Used to find the beginnings of sentences */
-  int nCol;
+    HighlightContext ctx;
+    int rc = SQLITE_OK;        /* Return code */
+    int iCol;                  /* 1st argument to snippet() */
+    const char* zEllips;       /* 4th argument to snippet() */
+    int nToken;                /* 5th argument to snippet() */
+    int nInst = 0;             /* Number of instance matches this row */
+    int i;                     /* Used to iterate through instances */
+    int nPhrase;               /* Number of phrases in query */
+    unsigned char* aSeen;      /* Array of "seen instance" flags */
+    int iBestCol;              /* Column containing best snippet */
+    int iBestStart = 0;        /* First token of best snippet */
+    int nBestScore = 0;        /* Score of best snippet */
+    int nColSize = 0;          /* Total size of iBestCol in tokens */
+    Fts5SnippetFinder sFinder; /* Used to find the beginnings of sentences */
+    int nCol;
 
-  if (nVal != 5) {
-    const char *zErr = "wrong number of arguments to function snippet()";
-    sqlite3_result_error(pCtx, zErr, -1);
-    return;
-  }
+    if (nVal != 5) {
+        const char* zErr = "wrong number of arguments to function snippet()";
+        sqlite3_result_error(pCtx, zErr, -1);
+        return;
+    }
 
-  nCol = pApi->xColumnCount(pFts);
-  memset(&ctx, 0, sizeof(HighlightContext));
-  iCol = sqlite3_value_int(apVal[0]);
-  ctx.zOpen = fts5ValueToText(apVal[1]);
-  ctx.zClose = fts5ValueToText(apVal[2]);
-  zEllips = fts5ValueToText(apVal[3]);
-  nToken = sqlite3_value_int(apVal[4]);
+    nCol = pApi->xColumnCount(pFts);
+    memset(&ctx, 0, sizeof(HighlightContext));
+    iCol = sqlite3_value_int(apVal[0]);
+    ctx.zOpen = fts5ValueToText(apVal[1]);
+    ctx.zClose = fts5ValueToText(apVal[2]);
+    zEllips = fts5ValueToText(apVal[3]);
+    nToken = sqlite3_value_int(apVal[4]);
 
-  iBestCol = (iCol >= 0 ? iCol : 0);
-  nPhrase = pApi->xPhraseCount(pFts);
-  aSeen = (unsigned char *)sqlite3_malloc(nPhrase);
-  if (aSeen == 0) {
-    rc = SQLITE_NOMEM;
-  }
-  if (rc == SQLITE_OK) {
-    rc = pApi->xInstCount(pFts, &nInst);
-  }
+    iBestCol = (iCol >= 0 ? iCol : 0);
+    nPhrase = pApi->xPhraseCount(pFts);
+    aSeen = (unsigned char*)sqlite3_malloc(nPhrase);
+    if (aSeen == 0) {
+        rc = SQLITE_NOMEM;
+    }
+    if (rc == SQLITE_OK) {
+        rc = pApi->xInstCount(pFts, &nInst);
+    }
 
-  memset(&sFinder, 0, sizeof(Fts5SnippetFinder));
-  for (i = 0; i < nCol; i++) {
-    if (iCol < 0 || iCol == i) {
-      int nDoc;
-      int nDocsize;
-      int ii;
-      sFinder.iPos = 0;
-      sFinder.nFirst = 0;
-      rc = pApi->xColumnText(pFts, i, &sFinder.zDoc, &nDoc);
-      if (rc != SQLITE_OK) break;
-      rc = pApi->xTokenize(pFts, sFinder.zDoc, nDoc, (void *)&sFinder, fts5SnippetFinderCb);
-      if (rc != SQLITE_OK) break;
-      rc = pApi->xColumnSize(pFts, i, &nDocsize);
-      if (rc != SQLITE_OK) break;
+    memset(&sFinder, 0, sizeof(Fts5SnippetFinder));
+    for (i = 0; i < nCol; i++) {
+        if (iCol < 0 || iCol == i) {
+            int nDoc;
+            int nDocsize;
+            int ii;
+            sFinder.iPos = 0;
+            sFinder.nFirst = 0;
+            rc = pApi->xColumnText(pFts, i, &sFinder.zDoc, &nDoc);
+            if (rc != SQLITE_OK)
+                break;
+            rc = pApi->xTokenize(pFts, sFinder.zDoc, nDoc, (void*)&sFinder, fts5SnippetFinderCb);
+            if (rc != SQLITE_OK)
+                break;
+            rc = pApi->xColumnSize(pFts, i, &nDocsize);
+            if (rc != SQLITE_OK)
+                break;
 
-      for (ii = 0; rc == SQLITE_OK && ii < nInst; ii++) {
-        int ip, ic, io;
-        int iAdj;
-        int nScore;
-        int jj;
+            for (ii = 0; rc == SQLITE_OK && ii < nInst; ii++) {
+                int ip, ic, io;
+                int iAdj;
+                int nScore;
+                int jj;
 
-        rc = pApi->xInst(pFts, ii, &ip, &ic, &io);
-        if (ic != i) continue;
-        if (io > nDocsize) rc = SQLITE_CORRUPT_VTAB;
-        if (rc != SQLITE_OK) continue;
-        memset(aSeen, 0, nPhrase);
-        rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, io, nToken, &nScore, &iAdj);
-        if (rc == SQLITE_OK && nScore > nBestScore) {
-          nBestScore = nScore;
-          iBestCol = i;
-          iBestStart = iAdj;
-          nColSize = nDocsize;
-        }
+                rc = pApi->xInst(pFts, ii, &ip, &ic, &io);
+                if (ic != i)
+                    continue;
+                if (io > nDocsize)
+                    rc = SQLITE_CORRUPT_VTAB;
+                if (rc != SQLITE_OK)
+                    continue;
+                memset(aSeen, 0, nPhrase);
+                rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, io, nToken, &nScore, &iAdj);
+                if (rc == SQLITE_OK && nScore > nBestScore) {
+                    nBestScore = nScore;
+                    iBestCol = i;
+                    iBestStart = iAdj;
+                    nColSize = nDocsize;
+                }
 
-        if (rc == SQLITE_OK && sFinder.nFirst && nDocsize > nToken) {
-          for (jj = 0; jj < (sFinder.nFirst - 1); jj++) {
-            if (sFinder.aFirst[jj + 1] > io) break;
-          }
+                if (rc == SQLITE_OK && sFinder.nFirst && nDocsize > nToken) {
+                    for (jj = 0; jj < (sFinder.nFirst - 1); jj++) {
+                        if (sFinder.aFirst[jj + 1] > io)
+                            break;
+                    }
 
-          if (sFinder.aFirst[jj] < io) {
-            memset(aSeen, 0, nPhrase);
-            rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, sFinder.aFirst[jj], nToken, &nScore, 0);
+                    if (sFinder.aFirst[jj] < io) {
+                        memset(aSeen, 0, nPhrase);
+                        rc = fts5SnippetScore(pApi, pFts, nDocsize, aSeen, i, sFinder.aFirst[jj], nToken, &nScore, 0);
 
-            nScore += (sFinder.aFirst[jj] == 0 ? 120 : 100);
-            if (rc == SQLITE_OK && nScore > nBestScore) {
-              nBestScore = nScore;
-              iBestCol = i;
-              iBestStart = sFinder.aFirst[jj];
-              nColSize = nDocsize;
+                        nScore += (sFinder.aFirst[jj] == 0 ? 120 : 100);
+                        if (rc == SQLITE_OK && nScore > nBestScore) {
+                            nBestScore = nScore;
+                            iBestCol = i;
+                            iBestStart = sFinder.aFirst[jj];
+                            nColSize = nDocsize;
+                        }
+                    }
+                }
             }
-          }
         }
-      }
-    }
-  }
-
-  if (rc == SQLITE_OK) {
-    rc = pApi->xColumnText(pFts, iBestCol, &ctx.zIn, &ctx.nIn);
-  }
-  if (rc == SQLITE_OK && nColSize == 0) {
-    rc = pApi->xColumnSize(pFts, iBestCol, &nColSize);
-  }
-  if (ctx.zIn) {
-    if (rc == SQLITE_OK) {
-      rc = fts5CInstIterInit(pApi, pFts, iBestCol, &ctx.iter);
-    }
-
-    ctx.iRangeStart = iBestStart;
-    ctx.iRangeEnd = iBestStart + nToken - 1;
-
-    if (iBestStart > 0) {
-      fts5HighlightAppend(&rc, &ctx, zEllips, -1);
-    }
-
-    /* Advance iterator ctx.iter so that it points to the first coalesced
-    ** phrase instance at or following position iBestStart. */
-    while (ctx.iter.iStart >= 0 && ctx.iter.iStart < iBestStart && rc == SQLITE_OK) {
-      rc = fts5CInstIterNext(&ctx.iter);
     }
 
     if (rc == SQLITE_OK) {
-      rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void *)&ctx, fts5HighlightCb);
+        rc = pApi->xColumnText(pFts, iBestCol, &ctx.zIn, &ctx.nIn);
     }
-    if (ctx.iRangeEnd >= (nColSize - 1)) {
-      fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+    if (rc == SQLITE_OK && nColSize == 0) {
+        rc = pApi->xColumnSize(pFts, iBestCol, &nColSize);
+    }
+    if (ctx.zIn) {
+        if (rc == SQLITE_OK) {
+            rc = fts5CInstIterInit(pApi, pFts, iBestCol, &ctx.iter);
+        }
+
+        ctx.iRangeStart = iBestStart;
+        ctx.iRangeEnd = iBestStart + nToken - 1;
+
+        if (iBestStart > 0) {
+            fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+        }
+
+        /* Advance iterator ctx.iter so that it points to the first coalesced
+        ** phrase instance at or following position iBestStart. */
+        while (ctx.iter.iStart >= 0 && ctx.iter.iStart < iBestStart && rc == SQLITE_OK) {
+            rc = fts5CInstIterNext(&ctx.iter);
+        }
+
+        if (rc == SQLITE_OK) {
+            rc = pApi->xTokenize(pFts, ctx.zIn, ctx.nIn, (void*)&ctx, fts5HighlightCb);
+        }
+        if (ctx.iRangeEnd >= (nColSize - 1)) {
+            fts5HighlightAppend(&rc, &ctx, &ctx.zIn[ctx.iOff], ctx.nIn - ctx.iOff);
+        } else {
+            fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+        }
+    }
+    if (rc == SQLITE_OK) {
+        sqlite3_result_text(pCtx, (const char*)ctx.zOut, -1, SQLITE_TRANSIENT);
     } else {
-      fts5HighlightAppend(&rc, &ctx, zEllips, -1);
+        sqlite3_result_error_code(pCtx, rc);
     }
-  }
-  if (rc == SQLITE_OK) {
-    sqlite3_result_text(pCtx, (const char *)ctx.zOut, -1, SQLITE_TRANSIENT);
-  } else {
-    sqlite3_result_error_code(pCtx, rc);
-  }
-  sqlite3_free(ctx.zOut);
-  sqlite3_free(aSeen);
-  sqlite3_free(sFinder.aFirst);
+    sqlite3_free(ctx.zOut);
+    sqlite3_free(aSeen);
+    sqlite3_free(sFinder.aFirst);
 }
 
 /************************************************************************/

--- a/src/simple_highlight.h
+++ b/src/simple_highlight.h
@@ -3,28 +3,25 @@
 
 #include "sqlite3ext.h"
 
-extern "C" void simple_highlight(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context* pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value** apVal         /* Array of trailing arguments */
+extern "C" void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                                 Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                                 sqlite3_context *pCtx,        /* Context for returning result/error */
+                                 int nVal,                     /* Number of values in apVal[] array */
+                                 sqlite3_value **apVal         /* Array of trailing arguments */
 );
 
-extern "C" void simple_snippet(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context* pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value** apVal         /* Array of trailing arguments */
+extern "C" void simple_snippet(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                               Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                               sqlite3_context *pCtx,        /* Context for returning result/error */
+                               int nVal,                     /* Number of values in apVal[] array */
+                               sqlite3_value **apVal         /* Array of trailing arguments */
 );
 
-extern "C" void simple_highlight_pos(
-    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
-    Fts5Context* pFts,            /* First arg to pass to pApi functions */
-    sqlite3_context* pCtx,        /* Context for returning result/error */
-    int nVal,                     /* Number of values in apVal[] array */
-    sqlite3_value** apVal         /* Array of trailing arguments */
+extern "C" void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
+                                     Fts5Context *pFts,            /* First arg to pass to pApi functions */
+                                     sqlite3_context *pCtx,        /* Context for returning result/error */
+                                     int nVal,                     /* Number of values in apVal[] array */
+                                     sqlite3_value **apVal         /* Array of trailing arguments */
 );
 
 #endif  // SIMPLE_HIGHLIGHT_H_

--- a/src/simple_highlight.h
+++ b/src/simple_highlight.h
@@ -3,25 +3,25 @@
 
 #include "sqlite3ext.h"
 
-extern "C" void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                                 Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                                 sqlite3_context *pCtx,        /* Context for returning result/error */
+extern "C" void simple_highlight(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                                 Fts5Context* pFts,            /* First arg to pass to pApi functions */
+                                 sqlite3_context* pCtx,        /* Context for returning result/error */
                                  int nVal,                     /* Number of values in apVal[] array */
-                                 sqlite3_value **apVal         /* Array of trailing arguments */
+                                 sqlite3_value** apVal         /* Array of trailing arguments */
 );
 
-extern "C" void simple_snippet(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                               Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                               sqlite3_context *pCtx,        /* Context for returning result/error */
+extern "C" void simple_snippet(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                               Fts5Context* pFts,            /* First arg to pass to pApi functions */
+                               sqlite3_context* pCtx,        /* Context for returning result/error */
                                int nVal,                     /* Number of values in apVal[] array */
-                               sqlite3_value **apVal         /* Array of trailing arguments */
+                               sqlite3_value** apVal         /* Array of trailing arguments */
 );
 
-extern "C" void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                                     Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                                     sqlite3_context *pCtx,        /* Context for returning result/error */
+extern "C" void simple_highlight_pos(const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+                                     Fts5Context* pFts,            /* First arg to pass to pApi functions */
+                                     sqlite3_context* pCtx,        /* Context for returning result/error */
                                      int nVal,                     /* Number of values in apVal[] array */
-                                     sqlite3_value **apVal         /* Array of trailing arguments */
+                                     sqlite3_value** apVal         /* Array of trailing arguments */
 );
 
 #endif  // SIMPLE_HIGHLIGHT_H_

--- a/src/simple_highlight.h
+++ b/src/simple_highlight.h
@@ -3,25 +3,28 @@
 
 #include "sqlite3ext.h"
 
-extern "C" void simple_highlight(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                                 Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                                 sqlite3_context *pCtx,        /* Context for returning result/error */
-                                 int nVal,                     /* Number of values in apVal[] array */
-                                 sqlite3_value **apVal         /* Array of trailing arguments */
+extern "C" void simple_highlight(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    sqlite3_context* pCtx,        /* Context for returning result/error */
+    int nVal,                     /* Number of values in apVal[] array */
+    sqlite3_value** apVal         /* Array of trailing arguments */
 );
 
-extern "C" void simple_snippet(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                               Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                               sqlite3_context *pCtx,        /* Context for returning result/error */
-                               int nVal,                     /* Number of values in apVal[] array */
-                               sqlite3_value **apVal         /* Array of trailing arguments */
+extern "C" void simple_snippet(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    sqlite3_context* pCtx,        /* Context for returning result/error */
+    int nVal,                     /* Number of values in apVal[] array */
+    sqlite3_value** apVal         /* Array of trailing arguments */
 );
 
-extern "C" void simple_highlight_pos(const Fts5ExtensionApi *pApi, /* API offered by current FTS version */
-                                     Fts5Context *pFts,            /* First arg to pass to pApi functions */
-                                     sqlite3_context *pCtx,        /* Context for returning result/error */
-                                     int nVal,                     /* Number of values in apVal[] array */
-                                     sqlite3_value **apVal         /* Array of trailing arguments */
+extern "C" void simple_highlight_pos(
+    const Fts5ExtensionApi* pApi, /* API offered by current FTS version */
+    Fts5Context* pFts,            /* First arg to pass to pApi functions */
+    sqlite3_context* pCtx,        /* Context for returning result/error */
+    int nVal,                     /* Number of values in apVal[] array */
+    sqlite3_value** apVal         /* Array of trailing arguments */
 );
 
 #endif  // SIMPLE_HIGHLIGHT_H_

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -10,179 +10,183 @@
 #include <vector>
 
 namespace simple_tokenizer {
-SimpleTokenizer::SimpleTokenizer(const char **azArg, int nArg) {
-  if (nArg >= 1) {
-    enable_pinyin = atoi(azArg[0]) != 0;
-  }
+SimpleTokenizer::SimpleTokenizer(const char** azArg, int nArg) {
+    if (nArg >= 1) {
+        enable_pinyin = atoi(azArg[0]) != 0;
+    }
 }
 
-PinYin *SimpleTokenizer::get_pinyin() {
-  static auto *py = new PinYin();
-  return py;
+PinYin* SimpleTokenizer::get_pinyin() {
+    static auto* py = new PinYin();
+    return py;
 }
 
 static TokenCategory from_char(char c) {
-  if (std::isdigit(c)) {
-    return TokenCategory::DIGIT;
-  }
-  if (std::isspace(c) || std::iscntrl(c)) {
-    return TokenCategory::SPACE;
-  }
-  if (std::isalpha(c)) {
-    return TokenCategory::ASCII_ALPHABETIC;
-  }
-  return TokenCategory::OTHER;
+    if (std::isdigit(c)) {
+        return TokenCategory::DIGIT;
+    }
+    if (std::isspace(c) || std::iscntrl(c)) {
+        return TokenCategory::SPACE;
+    }
+    if (std::isalpha(c)) {
+        return TokenCategory::ASCII_ALPHABETIC;
+    }
+    return TokenCategory::OTHER;
 }
 
-std::string SimpleTokenizer::tokenize_query(const char *text, int textLen, int flags) {
-  int start = 0;
-  int index = 0;
-  std::string tmp;
-  std::string result;
-  while (index < textLen) {
-    TokenCategory category = from_char(text[index]);
-    switch (category) {
-      case TokenCategory::OTHER:
-        index += PinYin::get_str_len(text[index]);
-        break;
-      default:
-        while (++index < textLen && from_char(text[index]) == category) {
+std::string SimpleTokenizer::tokenize_query(const char* text, int textLen, int flags) {
+    int start = 0;
+    int index = 0;
+    std::string tmp;
+    std::string result;
+    while (index < textLen) {
+        TokenCategory category = from_char(text[index]);
+        switch (category) {
+            case TokenCategory::OTHER:
+                index += PinYin::get_str_len(text[index]);
+                break;
+            default:
+                while (++index < textLen && from_char(text[index]) == category) {
+                }
+                break;
         }
-        break;
+        tmp.clear();
+        std::copy(text + start, text + index, std::back_inserter(tmp));
+        append_result(result, tmp, category, start, flags);
+        start = index;
     }
-    tmp.clear();
-    std::copy(text + start, text + index, std::back_inserter(tmp));
-    append_result(result, tmp, category, start, flags);
-    start = index;
-  }
-  return result;
+    return result;
 }
 
 #ifdef USE_JIEBA
 std::string jieba_dict_path = "./dict/";
-std::string SimpleTokenizer::tokenize_jieba_query(
-    const char* text,
-    int textLen,
-    int flags,
-    QueryOption option /* = kJiebaCutWithoutHMM */) {
-  (void)textLen;
-    static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8",
-                                jieba_dict_path + "hmm_model.utf8",
-                                jieba_dict_path + "user.dict.utf8",
-                                jieba_dict_path + "idf.utf8",
-                                jieba_dict_path + "stop_words.utf8");
-  std::string tmp;
-  std::string result;
-  std::vector<cppjieba::Word> words;
-  switch (option) {
-      case kJiebaCutWithHMM:
-          jieba.Cut(text, words);
-          break;
-      case kJiebaCutWithoutHMM:
-          jieba.Cut(text, words, false);
-          break;
-      case kJiebaCutAll:
-          jieba.CutAll(text, words);
-          break;
-      case kJiebaCutForSearch:
-          jieba.CutForSearch(text, words);
-          break;
-      case kJiebaCutHMM:
-          jieba.CutHMM(text, words);
-          break;
-      case kJiebaCutSmall:
-          // jieba.CutSmall(text, words);
-          break;
-      default:
-          break;
-  }
+std::string SimpleTokenizer::tokenize_jieba_query(const char* text,
+                                                  int textLen,
+                                                  int flags,
+                                                  QueryOption option /* = kJiebaCutWithoutHMM */) {
+    (void)textLen;
+    static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8", jieba_dict_path + "hmm_model.utf8",
+                                 jieba_dict_path + "user.dict.utf8", jieba_dict_path + "idf.utf8",
+                                 jieba_dict_path + "stop_words.utf8");
+    std::string tmp;
+    std::string result;
+    std::vector<cppjieba::Word> words;
+    switch (option) {
+        case kJiebaCutWithHMM:
+            jieba.Cut(text, words);
+            break;
+        case kJiebaCutWithoutHMM:
+            jieba.Cut(text, words, false);
+            break;
+        case kJiebaCutAll:
+            jieba.CutAll(text, words);
+            break;
+        case kJiebaCutForSearch:
+            jieba.CutForSearch(text, words);
+            break;
+        case kJiebaCutHMM:
+            jieba.CutHMM(text, words);
+            break;
+        case kJiebaCutSmall:
+            // jieba.CutSmall(text, words);
+            break;
+        default:
+            break;
+    }
 
-  for (auto word : words) {
-      TokenCategory category = from_char(text[word.offset]);
-      append_result(result, word.word, category, word.offset, flags);
-  }
-  return result;
+    for (auto word : words) {
+        TokenCategory category = from_char(text[word.offset]);
+        append_result(result, word.word, category, word.offset, flags);
+    }
+    return result;
 }
 #endif
 
-void SimpleTokenizer::append_result(std::string &result, std::string part, TokenCategory category, int offset,
+void SimpleTokenizer::append_result(std::string& result,
+                                    std::string part,
+                                    TokenCategory category,
+                                    int offset,
                                     int flags) {
-  if (category != TokenCategory::SPACE) {
-    std::string tmp = std::move(part);
-    if (category == TokenCategory::ASCII_ALPHABETIC) {
-      std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) { return std::tolower(c); });
-    }
-
-    if (flags != 0 && category == TokenCategory::ASCII_ALPHABETIC && tmp.size() > 1) {
-      if (offset == 0) {
-        result.append("( ");
-      } else {
-        result.append(" AND ( ");
-      }
-      std::set<std::string> pys = SimpleTokenizer::get_pinyin()->split_pinyin(tmp);
-      bool addOr = false;
-      for (const std::string &s : pys) {
-        if (addOr) {
-          result.append(" OR ");
+    if (category != TokenCategory::SPACE) {
+        std::string tmp = std::move(part);
+        if (category == TokenCategory::ASCII_ALPHABETIC) {
+            std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) {
+                return std::tolower(c);
+            });
         }
-        result.append(s);
-        result.append("*");
-        addOr = true;
-      }
-      result.append(" )");
-    } else {
-      if (offset > 0) {
-        result.append(" AND ");
-      }
-      if (tmp == "\"") {
-        tmp += tmp;
-      }
-      if (category != TokenCategory::ASCII_ALPHABETIC) {
-        result.append('"' + tmp + '"');
-      } else {
-        result.append(tmp);
-      }
-      if (category != TokenCategory::OTHER) {
-        result.append("*");
-      }
+
+        if (flags != 0 && category == TokenCategory::ASCII_ALPHABETIC && tmp.size() > 1) {
+            if (offset == 0) {
+                result.append("( ");
+            } else {
+                result.append(" AND ( ");
+            }
+            std::set<std::string> pys = SimpleTokenizer::get_pinyin()->split_pinyin(tmp);
+            bool addOr = false;
+            for (const std::string& s : pys) {
+                if (addOr) {
+                    result.append(" OR ");
+                }
+                result.append(s);
+                result.append("*");
+                addOr = true;
+            }
+            result.append(" )");
+        } else {
+            if (offset > 0) {
+                result.append(" AND ");
+            }
+            if (tmp == "\"") {
+                tmp += tmp;
+            }
+            if (category != TokenCategory::ASCII_ALPHABETIC) {
+                result.append('"' + tmp + '"');
+            } else {
+                result.append(tmp);
+            }
+            if (category != TokenCategory::OTHER) {
+                result.append("*");
+            }
+        }
     }
-  }
 }
 
 // https://cloud.tencent.com/developer/article/1198371
-int SimpleTokenizer::tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const {
-  int rc = SQLITE_OK;
-  int start = 0;
-  int index = 0;
-  std::string result;
-  while (index < textLen) {
-    TokenCategory category = from_char(text[index]);
-    switch (category) {
-      case TokenCategory::OTHER:
-        index += PinYin::get_str_len(text[index]);
-        break;
-      default:
-        while (++index < textLen && from_char(text[index]) == category) {
+int SimpleTokenizer::tokenize(void* pCtx, int flags, const char* text, int textLen, xTokenFn xToken) const {
+    int rc = SQLITE_OK;
+    int start = 0;
+    int index = 0;
+    std::string result;
+    while (index < textLen) {
+        TokenCategory category = from_char(text[index]);
+        switch (category) {
+            case TokenCategory::OTHER:
+                index += PinYin::get_str_len(text[index]);
+                break;
+            default:
+                while (++index < textLen && from_char(text[index]) == category) {
+                }
+                break;
         }
-        break;
-    }
-    if (category != TokenCategory::SPACE) {
-      result.clear();
-      std::copy(text + start, text + index, std::back_inserter(result));
-      if (category == TokenCategory::ASCII_ALPHABETIC) {
-        std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
-      }
+        if (category != TokenCategory::SPACE) {
+            result.clear();
+            std::copy(text + start, text + index, std::back_inserter(result));
+            if (category == TokenCategory::ASCII_ALPHABETIC) {
+                std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) {
+                    return std::tolower(c);
+                });
+            }
 
-      rc = xToken(pCtx, 0, result.c_str(), (int)result.length(), start, index);
-      if (enable_pinyin && category == TokenCategory::OTHER && (flags & FTS5_TOKENIZE_DOCUMENT)) {
-        const std::vector<std::string> &pys = SimpleTokenizer::get_pinyin()->get_pinyin(result);
-        for (const std::string &s : pys) {
-          rc = xToken(pCtx, FTS5_TOKEN_COLOCATED, s.c_str(), (int)s.length(), start, index);
+            rc = xToken(pCtx, 0, result.c_str(), (int)result.length(), start, index);
+            if (enable_pinyin && category == TokenCategory::OTHER && (flags & FTS5_TOKENIZE_DOCUMENT)) {
+                const std::vector<std::string>& pys = SimpleTokenizer::get_pinyin()->get_pinyin(result);
+                for (const std::string& s : pys) {
+                    rc = xToken(pCtx, FTS5_TOKEN_COLOCATED, s.c_str(), (int)s.length(), start, index);
+                }
+            }
         }
-      }
+        start = index;
     }
-    start = index;
-  }
-  return rc;
+    return rc;
 }
 }  // namespace simple_tokenizer

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -10,55 +10,52 @@
 #include <vector>
 
 namespace simple_tokenizer {
-SimpleTokenizer::SimpleTokenizer(const char** azArg, int nArg) {
-    if (nArg >= 1) {
-        enable_pinyin = atoi(azArg[0]) != 0;
-    }
+SimpleTokenizer::SimpleTokenizer(const char **azArg, int nArg) {
+  if (nArg >= 1) {
+    enable_pinyin = atoi(azArg[0]) != 0;
+  }
 }
 
-PinYin* SimpleTokenizer::get_pinyin() {
-    static auto* py = new PinYin();
-    return py;
+PinYin *SimpleTokenizer::get_pinyin() {
+  static auto *py = new PinYin();
+  return py;
 }
 
 static TokenCategory from_char(char c) {
-    if (std::isdigit(c)) {
-        return TokenCategory::DIGIT;
-    }
-    if (std::isspace(c) || std::iscntrl(c)) {
-        return TokenCategory::SPACE;
-    }
-    if (std::isalpha(c)) {
-        return TokenCategory::ASCII_ALPHABETIC;
-    }
-    return TokenCategory::OTHER;
+  if (std::isdigit(c)) {
+    return TokenCategory::DIGIT;
+  }
+  if (std::isspace(c) || std::iscntrl(c)) {
+    return TokenCategory::SPACE;
+  }
+  if (std::isalpha(c)) {
+    return TokenCategory::ASCII_ALPHABETIC;
+  }
+  return TokenCategory::OTHER;
 }
 
-std::string SimpleTokenizer::tokenize_query(const char* text,
-                                            int textLen,
-                                            int flags) {
-    int start = 0;
-    int index = 0;
-    std::string tmp;
-    std::string result;
-    while (index < textLen) {
-        TokenCategory category = from_char(text[index]);
-        switch (category) {
-            case TokenCategory::OTHER:
-                index += PinYin::get_str_len(text[index]);
-                break;
-            default:
-                while (++index < textLen &&
-                       from_char(text[index]) == category) {
-                }
-                break;
+std::string SimpleTokenizer::tokenize_query(const char *text, int textLen, int flags) {
+  int start = 0;
+  int index = 0;
+  std::string tmp;
+  std::string result;
+  while (index < textLen) {
+    TokenCategory category = from_char(text[index]);
+    switch (category) {
+      case TokenCategory::OTHER:
+        index += PinYin::get_str_len(text[index]);
+        break;
+      default:
+        while (++index < textLen && from_char(text[index]) == category) {
         }
-        tmp.clear();
-        std::copy(text + start, text + index, std::back_inserter(tmp));
-        append_result(result, tmp, category, start, flags);
-        start = index;
+        break;
     }
-    return result;
+    tmp.clear();
+    std::copy(text + start, text + index, std::back_inserter(tmp));
+    append_result(result, tmp, category, start, flags);
+    start = index;
+  }
+  return result;
 }
 
 #ifdef USE_JIEBA
@@ -68,142 +65,124 @@ std::string SimpleTokenizer::tokenize_jieba_query(
     int textLen,
     int flags,
     QueryOption option /* = kJiebaCutWithoutHMM */) {
-    (void)textLen;
-    static cppjieba::Jieba jieba(
-        jieba_dict_path + "jieba.dict.utf8", jieba_dict_path + "hmm_model.utf8",
-        jieba_dict_path + "user.dict.utf8", jieba_dict_path + "idf.utf8",
-        jieba_dict_path + "stop_words.utf8");
-    std::string tmp;
-    std::string result;
-    std::vector<cppjieba::Word> words;
-    switch (option) {
-        case kJiebaCutWithHMM:
-            jieba.Cut(text, words);
-            break;
-        case kJiebaCutWithoutHMM:
-            jieba.Cut(text, words, false);
-            break;
-        case kJiebaCutAll:
-            jieba.CutAll(text, words);
-            break;
-        case kJiebaCutForSearch:
-            jieba.CutForSearch(text, words);
-            break;
-        case kJiebaCutHMM:
-            jieba.CutHMM(text, words);
-            break;
-        case kJiebaCutSmall:
-            break;
-        default:
-            break;
-    }
+  (void)textLen;
+    static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8",
+                                jieba_dict_path + "hmm_model.utf8",
+                                jieba_dict_path + "user.dict.utf8",
+                                jieba_dict_path + "idf.utf8",
+                                jieba_dict_path + "stop_words.utf8");
+  std::string tmp;
+  std::string result;
+  std::vector<cppjieba::Word> words;
+  switch (option) {
+      case kJiebaCutWithHMM:
+          jieba.Cut(text, words);
+          break;
+      case kJiebaCutWithoutHMM:
+          jieba.Cut(text, words, false);
+          break;
+      case kJiebaCutAll:
+          jieba.CutAll(text, words);
+          break;
+      case kJiebaCutForSearch:
+          jieba.CutForSearch(text, words);
+          break;
+      case kJiebaCutHMM:
+          jieba.CutHMM(text, words);
+          break;
+      case kJiebaCutSmall:
+          // jieba.CutSmall(text, words);
+          break;
+      default:
+          break;
+  }
 
-    for (auto word : words) {
-        TokenCategory category = from_char(text[word.offset]);
-        append_result(result, word.word, category, word.offset, flags);
-    }
-    return result;
+  for (auto word : words) {
+      TokenCategory category = from_char(text[word.offset]);
+      append_result(result, word.word, category, word.offset, flags);
+  }
+  return result;
 }
 #endif
 
-void SimpleTokenizer::append_result(std::string& result,
-                                    std::string part,
-                                    TokenCategory category,
-                                    int offset,
+void SimpleTokenizer::append_result(std::string &result, std::string part, TokenCategory category, int offset,
                                     int flags) {
-    if (category != TokenCategory::SPACE) {
-        std::string tmp = std::move(part);
-        if (category == TokenCategory::ASCII_ALPHABETIC) {
-            std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                           [](unsigned char c) {
-                               return std::tolower(c);
-                           });
-        }
-
-        if (flags != 0 && category == TokenCategory::ASCII_ALPHABETIC &&
-            tmp.size() > 1) {
-            if (offset == 0) {
-                result.append("( ");
-            } else {
-                result.append(" AND ( ");
-            }
-            std::set<std::string> pys =
-                SimpleTokenizer::get_pinyin()->split_pinyin(tmp);
-            bool addOr = false;
-            for (const std::string& s : pys) {
-                if (addOr) {
-                    result.append(" OR ");
-                }
-                result.append(s);
-                result.append("*");
-                addOr = true;
-            }
-            result.append(" )");
-        } else {
-            if (offset > 0) {
-                result.append(" AND ");
-            }
-            if (tmp == "\"") {
-                tmp += tmp;
-            }
-            if (category != TokenCategory::ASCII_ALPHABETIC) {
-                result.append('"' + tmp + '"');
-            } else {
-                result.append(tmp);
-            }
-            if (category != TokenCategory::OTHER) {
-                result.append("*");
-            }
-        }
+  if (category != TokenCategory::SPACE) {
+    std::string tmp = std::move(part);
+    if (category == TokenCategory::ASCII_ALPHABETIC) {
+      std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) { return std::tolower(c); });
     }
+
+    if (flags != 0 && category == TokenCategory::ASCII_ALPHABETIC && tmp.size() > 1) {
+      if (offset == 0) {
+        result.append("( ");
+      } else {
+        result.append(" AND ( ");
+      }
+      std::set<std::string> pys = SimpleTokenizer::get_pinyin()->split_pinyin(tmp);
+      bool addOr = false;
+      for (const std::string &s : pys) {
+        if (addOr) {
+          result.append(" OR ");
+        }
+        result.append(s);
+        result.append("*");
+        addOr = true;
+      }
+      result.append(" )");
+    } else {
+      if (offset > 0) {
+        result.append(" AND ");
+      }
+      if (tmp == "\"") {
+        tmp += tmp;
+      }
+      if (category != TokenCategory::ASCII_ALPHABETIC) {
+        result.append('"' + tmp + '"');
+      } else {
+        result.append(tmp);
+      }
+      if (category != TokenCategory::OTHER) {
+        result.append("*");
+      }
+    }
+  }
 }
 
 // https://cloud.tencent.com/developer/article/1198371
-int SimpleTokenizer::tokenize(void* pCtx,
-                              int flags,
-                              const char* text,
-                              int textLen,
-                              xTokenFn xToken) const {
-    int rc = SQLITE_OK;
-    int start = 0;
-    int index = 0;
-    std::string result;
-    while (index < textLen) {
-        TokenCategory category = from_char(text[index]);
-        switch (category) {
-            case TokenCategory::OTHER:
-                index += PinYin::get_str_len(text[index]);
-                break;
-            default:
-                while (++index < textLen &&
-                       from_char(text[index]) == category) {
-                }
-                break;
+int SimpleTokenizer::tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const {
+  int rc = SQLITE_OK;
+  int start = 0;
+  int index = 0;
+  std::string result;
+  while (index < textLen) {
+    TokenCategory category = from_char(text[index]);
+    switch (category) {
+      case TokenCategory::OTHER:
+        index += PinYin::get_str_len(text[index]);
+        break;
+      default:
+        while (++index < textLen && from_char(text[index]) == category) {
         }
-        if (category != TokenCategory::SPACE) {
-            result.clear();
-            std::copy(text + start, text + index, std::back_inserter(result));
-            if (category == TokenCategory::ASCII_ALPHABETIC) {
-                std::transform(result.begin(), result.end(), result.begin(),
-                               [](unsigned char c) {
-                                   return std::tolower(c);
-                               });
-            }
-
-            rc = xToken(pCtx, 0, result.c_str(), (int)result.length(), start,
-                        index);
-            if (enable_pinyin && category == TokenCategory::OTHER &&
-                (flags & FTS5_TOKENIZE_DOCUMENT)) {
-                const std::vector<std::string>& pys =
-                    SimpleTokenizer::get_pinyin()->get_pinyin(result);
-                for (const std::string& s : pys) {
-                    rc = xToken(pCtx, FTS5_TOKEN_COLOCATED, s.c_str(),
-                                (int)s.length(), start, index);
-                }
-            }
-        }
-        start = index;
+        break;
     }
-    return rc;
+    if (category != TokenCategory::SPACE) {
+      result.clear();
+      std::copy(text + start, text + index, std::back_inserter(result));
+      if (category == TokenCategory::ASCII_ALPHABETIC) {
+        std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
+      }
+
+      rc = xToken(pCtx, 0, result.c_str(), (int)result.length(), start, index);
+      if (enable_pinyin && category == TokenCategory::OTHER && (flags & FTS5_TOKENIZE_DOCUMENT)) {
+        const std::vector<std::string> &pys = SimpleTokenizer::get_pinyin()->get_pinyin(result);
+        for (const std::string &s : pys) {
+          rc = xToken(pCtx, FTS5_TOKEN_COLOCATED, s.c_str(), (int)s.length(), start, index);
+        }
+      }
+    }
+    start = index;
+  }
+  return rc;
 }
 }  // namespace simple_tokenizer

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -10,52 +10,55 @@
 #include <vector>
 
 namespace simple_tokenizer {
-SimpleTokenizer::SimpleTokenizer(const char **azArg, int nArg) {
-  if (nArg >= 1) {
-    enable_pinyin = atoi(azArg[0]) != 0;
-  }
+SimpleTokenizer::SimpleTokenizer(const char** azArg, int nArg) {
+    if (nArg >= 1) {
+        enable_pinyin = atoi(azArg[0]) != 0;
+    }
 }
 
-PinYin *SimpleTokenizer::get_pinyin() {
-  static auto *py = new PinYin();
-  return py;
+PinYin* SimpleTokenizer::get_pinyin() {
+    static auto* py = new PinYin();
+    return py;
 }
 
 static TokenCategory from_char(char c) {
-  if (std::isdigit(c)) {
-    return TokenCategory::DIGIT;
-  }
-  if (std::isspace(c) || std::iscntrl(c)) {
-    return TokenCategory::SPACE;
-  }
-  if (std::isalpha(c)) {
-    return TokenCategory::ASCII_ALPHABETIC;
-  }
-  return TokenCategory::OTHER;
+    if (std::isdigit(c)) {
+        return TokenCategory::DIGIT;
+    }
+    if (std::isspace(c) || std::iscntrl(c)) {
+        return TokenCategory::SPACE;
+    }
+    if (std::isalpha(c)) {
+        return TokenCategory::ASCII_ALPHABETIC;
+    }
+    return TokenCategory::OTHER;
 }
 
-std::string SimpleTokenizer::tokenize_query(const char *text, int textLen, int flags) {
-  int start = 0;
-  int index = 0;
-  std::string tmp;
-  std::string result;
-  while (index < textLen) {
-    TokenCategory category = from_char(text[index]);
-    switch (category) {
-      case TokenCategory::OTHER:
-        index += PinYin::get_str_len(text[index]);
-        break;
-      default:
-        while (++index < textLen && from_char(text[index]) == category) {
+std::string SimpleTokenizer::tokenize_query(const char* text,
+                                            int textLen,
+                                            int flags) {
+    int start = 0;
+    int index = 0;
+    std::string tmp;
+    std::string result;
+    while (index < textLen) {
+        TokenCategory category = from_char(text[index]);
+        switch (category) {
+            case TokenCategory::OTHER:
+                index += PinYin::get_str_len(text[index]);
+                break;
+            default:
+                while (++index < textLen &&
+                       from_char(text[index]) == category) {
+                }
+                break;
         }
-        break;
+        tmp.clear();
+        std::copy(text + start, text + index, std::back_inserter(tmp));
+        append_result(result, tmp, category, start, flags);
+        start = index;
     }
-    tmp.clear();
-    std::copy(text + start, text + index, std::back_inserter(tmp));
-    append_result(result, tmp, category, start, flags);
-    start = index;
-  }
-  return result;
+    return result;
 }
 
 #ifdef USE_JIEBA
@@ -65,124 +68,142 @@ std::string SimpleTokenizer::tokenize_jieba_query(
     int textLen,
     int flags,
     QueryOption option /* = kJiebaCutWithoutHMM */) {
-  (void)textLen;
-    static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8",
-                                jieba_dict_path + "hmm_model.utf8",
-                                jieba_dict_path + "user.dict.utf8",
-                                jieba_dict_path + "idf.utf8",
-                                jieba_dict_path + "stop_words.utf8");
-  std::string tmp;
-  std::string result;
-  std::vector<cppjieba::Word> words;
-  switch (option) {
-      case kJiebaCutWithHMM:
-          jieba.Cut(text, words);
-          break;
-      case kJiebaCutWithoutHMM:
-          jieba.Cut(text, words, false);
-          break;
-      case kJiebaCutAll:
-          jieba.CutAll(text, words);
-          break;
-      case kJiebaCutForSearch:
-          jieba.CutForSearch(text, words);
-          break;
-      case kJiebaCutHMM:
-          jieba.CutHMM(text, words);
-          break;
-      case kJiebaCutSmall:
-          // jieba.CutSmall(text, words);
-          break;
-      default:
-          break;
-  }
+    (void)textLen;
+    static cppjieba::Jieba jieba(
+        jieba_dict_path + "jieba.dict.utf8", jieba_dict_path + "hmm_model.utf8",
+        jieba_dict_path + "user.dict.utf8", jieba_dict_path + "idf.utf8",
+        jieba_dict_path + "stop_words.utf8");
+    std::string tmp;
+    std::string result;
+    std::vector<cppjieba::Word> words;
+    switch (option) {
+        case kJiebaCutWithHMM:
+            jieba.Cut(text, words);
+            break;
+        case kJiebaCutWithoutHMM:
+            jieba.Cut(text, words, false);
+            break;
+        case kJiebaCutAll:
+            jieba.CutAll(text, words);
+            break;
+        case kJiebaCutForSearch:
+            jieba.CutForSearch(text, words);
+            break;
+        case kJiebaCutHMM:
+            jieba.CutHMM(text, words);
+            break;
+        case kJiebaCutSmall:
+            break;
+        default:
+            break;
+    }
 
-  for (auto word : words) {
-      TokenCategory category = from_char(text[word.offset]);
-      append_result(result, word.word, category, word.offset, flags);
-  }
-  return result;
+    for (auto word : words) {
+        TokenCategory category = from_char(text[word.offset]);
+        append_result(result, word.word, category, word.offset, flags);
+    }
+    return result;
 }
 #endif
 
-void SimpleTokenizer::append_result(std::string &result, std::string part, TokenCategory category, int offset,
+void SimpleTokenizer::append_result(std::string& result,
+                                    std::string part,
+                                    TokenCategory category,
+                                    int offset,
                                     int flags) {
-  if (category != TokenCategory::SPACE) {
-    std::string tmp = std::move(part);
-    if (category == TokenCategory::ASCII_ALPHABETIC) {
-      std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](unsigned char c) { return std::tolower(c); });
-    }
-
-    if (flags != 0 && category == TokenCategory::ASCII_ALPHABETIC && tmp.size() > 1) {
-      if (offset == 0) {
-        result.append("( ");
-      } else {
-        result.append(" AND ( ");
-      }
-      std::set<std::string> pys = SimpleTokenizer::get_pinyin()->split_pinyin(tmp);
-      bool addOr = false;
-      for (const std::string &s : pys) {
-        if (addOr) {
-          result.append(" OR ");
+    if (category != TokenCategory::SPACE) {
+        std::string tmp = std::move(part);
+        if (category == TokenCategory::ASCII_ALPHABETIC) {
+            std::transform(tmp.begin(), tmp.end(), tmp.begin(),
+                           [](unsigned char c) {
+                               return std::tolower(c);
+                           });
         }
-        result.append(s);
-        result.append("*");
-        addOr = true;
-      }
-      result.append(" )");
-    } else {
-      if (offset > 0) {
-        result.append(" AND ");
-      }
-      if (tmp == "\"") {
-        tmp += tmp;
-      }
-      if (category != TokenCategory::ASCII_ALPHABETIC) {
-        result.append('"' + tmp + '"');
-      } else {
-        result.append(tmp);
-      }
-      if (category != TokenCategory::OTHER) {
-        result.append("*");
-      }
+
+        if (flags != 0 && category == TokenCategory::ASCII_ALPHABETIC &&
+            tmp.size() > 1) {
+            if (offset == 0) {
+                result.append("( ");
+            } else {
+                result.append(" AND ( ");
+            }
+            std::set<std::string> pys =
+                SimpleTokenizer::get_pinyin()->split_pinyin(tmp);
+            bool addOr = false;
+            for (const std::string& s : pys) {
+                if (addOr) {
+                    result.append(" OR ");
+                }
+                result.append(s);
+                result.append("*");
+                addOr = true;
+            }
+            result.append(" )");
+        } else {
+            if (offset > 0) {
+                result.append(" AND ");
+            }
+            if (tmp == "\"") {
+                tmp += tmp;
+            }
+            if (category != TokenCategory::ASCII_ALPHABETIC) {
+                result.append('"' + tmp + '"');
+            } else {
+                result.append(tmp);
+            }
+            if (category != TokenCategory::OTHER) {
+                result.append("*");
+            }
+        }
     }
-  }
 }
 
 // https://cloud.tencent.com/developer/article/1198371
-int SimpleTokenizer::tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const {
-  int rc = SQLITE_OK;
-  int start = 0;
-  int index = 0;
-  std::string result;
-  while (index < textLen) {
-    TokenCategory category = from_char(text[index]);
-    switch (category) {
-      case TokenCategory::OTHER:
-        index += PinYin::get_str_len(text[index]);
-        break;
-      default:
-        while (++index < textLen && from_char(text[index]) == category) {
+int SimpleTokenizer::tokenize(void* pCtx,
+                              int flags,
+                              const char* text,
+                              int textLen,
+                              xTokenFn xToken) const {
+    int rc = SQLITE_OK;
+    int start = 0;
+    int index = 0;
+    std::string result;
+    while (index < textLen) {
+        TokenCategory category = from_char(text[index]);
+        switch (category) {
+            case TokenCategory::OTHER:
+                index += PinYin::get_str_len(text[index]);
+                break;
+            default:
+                while (++index < textLen &&
+                       from_char(text[index]) == category) {
+                }
+                break;
         }
-        break;
-    }
-    if (category != TokenCategory::SPACE) {
-      result.clear();
-      std::copy(text + start, text + index, std::back_inserter(result));
-      if (category == TokenCategory::ASCII_ALPHABETIC) {
-        std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
-      }
+        if (category != TokenCategory::SPACE) {
+            result.clear();
+            std::copy(text + start, text + index, std::back_inserter(result));
+            if (category == TokenCategory::ASCII_ALPHABETIC) {
+                std::transform(result.begin(), result.end(), result.begin(),
+                               [](unsigned char c) {
+                                   return std::tolower(c);
+                               });
+            }
 
-      rc = xToken(pCtx, 0, result.c_str(), (int)result.length(), start, index);
-      if (enable_pinyin && category == TokenCategory::OTHER && (flags & FTS5_TOKENIZE_DOCUMENT)) {
-        const std::vector<std::string> &pys = SimpleTokenizer::get_pinyin()->get_pinyin(result);
-        for (const std::string &s : pys) {
-          rc = xToken(pCtx, FTS5_TOKEN_COLOCATED, s.c_str(), (int)s.length(), start, index);
+            rc = xToken(pCtx, 0, result.c_str(), (int)result.length(), start,
+                        index);
+            if (enable_pinyin && category == TokenCategory::OTHER &&
+                (flags & FTS5_TOKENIZE_DOCUMENT)) {
+                const std::vector<std::string>& pys =
+                    SimpleTokenizer::get_pinyin()->get_pinyin(result);
+                for (const std::string& s : pys) {
+                    rc = xToken(pCtx, FTS5_TOKEN_COLOCATED, s.c_str(),
+                                (int)s.length(), start, index);
+                }
+            }
         }
-      }
+        start = index;
     }
-    start = index;
-  }
-  return rc;
+    return rc;
 }
 }  // namespace simple_tokenizer

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -60,18 +60,46 @@ std::string SimpleTokenizer::tokenize_query(const char *text, int textLen, int f
 
 #ifdef USE_JIEBA
 std::string jieba_dict_path = "./dict/";
-std::string SimpleTokenizer::tokenize_jieba_query(const char *text, int textLen, int flags) {
+std::string SimpleTokenizer::tokenize_jieba_query(
+    const char* text,
+    int textLen,
+    int flags,
+    QueryOption option /* = kJiebaCutWithoutHMM */) {
   (void)textLen;
-  static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8", jieba_dict_path + "hmm_model.utf8",
-                               jieba_dict_path + "user.dict.utf8", jieba_dict_path + "idf.utf8",
-                               jieba_dict_path + "stop_words.utf8");
+    static cppjieba::Jieba jieba(jieba_dict_path + "jieba.dict.utf8",
+                                jieba_dict_path + "hmm_model.utf8",
+                                jieba_dict_path + "user.dict.utf8",
+                                jieba_dict_path + "idf.utf8",
+                                jieba_dict_path + "stop_words.utf8");
   std::string tmp;
   std::string result;
   std::vector<cppjieba::Word> words;
-  jieba.Cut(text, words);
+  switch (option) {
+      case kJiebaCutWithHMM:
+          jieba.Cut(text, words);
+          break;
+      case kJiebaCutWithoutHMM:
+          jieba.Cut(text, words, false);
+          break;
+      case kJiebaCutAll:
+          jieba.CutAll(text, words);
+          break;
+      case kJiebaCutForSearch:
+          jieba.CutForSearch(text, words);
+          break;
+      case kJiebaCutHMM:
+          jieba.CutHMM(text, words);
+          break;
+      case kJiebaCutSmall:
+          // jieba.CutSmall(text, words);
+          break;
+      default:
+          break;
+  }
+
   for (auto word : words) {
-    TokenCategory category = from_char(text[word.offset]);
-    append_result(result, word.word, category, word.offset, flags);
+      TokenCategory category = from_char(text[word.offset]);
+      append_result(result, word.word, category, word.offset, flags);
   }
   return result;
 }

--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -25,7 +25,7 @@ static TokenCategory from_char(char c) {
   if (std::isdigit(c)) {
     return TokenCategory::DIGIT;
   }
-  if (std::isspace(c)) {
+  if (std::isspace(c) || std::iscntrl(c)) {
     return TokenCategory::SPACE;
   }
   if (std::isalpha(c)) {

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -8,6 +8,7 @@
 #endif
 #include "pinyin.h"
 #include "sqlite3ext.h"
+#include "simple_def.h"
 
 typedef int (*xTokenFn)(void *, int, const char *, int, int, int);
 
@@ -34,7 +35,7 @@ class SimpleTokenizer {
   int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const;
   static std::string tokenize_query(const char *text, int textLen, int flags = 1);
 #ifdef USE_JIEBA
-  static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1);
+  static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1, QueryOption option = kJiebaCutWithoutHMM);
 #endif
 
  private:

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -2,15 +2,14 @@
 #define SIMPLE_TOKENIZER_H_
 
 #include <memory>
-
+#include "pinyin.h"
+#include "simple_def.h"
+#include "sqlite3ext.h"
 #ifdef USE_JIEBA
 #include "cppjieba/Jieba.hpp"
 #endif
-#include "pinyin.h"
-#include "sqlite3ext.h"
-#include "simple_def.h"
 
-typedef int (*xTokenFn)(void *, int, const char *, int, int, int);
+typedef int (*xTokenFn)(void*, int, const char*, int, int, int);
 
 namespace simple_tokenizer {
 
@@ -19,36 +18,43 @@ extern std::string jieba_dict_path;
 #endif
 
 enum class TokenCategory {
-  SPACE,
-  ASCII_ALPHABETIC,
-  DIGIT,
-  OTHER,
+    SPACE,
+    ASCII_ALPHABETIC,
+    DIGIT,
+    OTHER,
 };
 
 class SimpleTokenizer {
- private:
-  static PinYin *get_pinyin();
-  bool enable_pinyin = true;
+private:
+    static PinYin* get_pinyin();
+    bool enable_pinyin = true;
 
- public:
-  SimpleTokenizer(const char **zaArg, int nArg);
-  int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const;
-  static std::string tokenize_query(const char *text, int textLen, int flags = 1);
+public:
+    SimpleTokenizer(const char** zaArg, int nArg);
+    int tokenize(void* pCtx, int flags, const char* text, int textLen, xTokenFn xToken) const;
+    static std::string tokenize_query(const char* text, int textLen, int flags = 1);
 #ifdef USE_JIEBA
-  static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1, QueryOption option = kJiebaCutWithoutHMM);
+    static std::string tokenize_jieba_query(const char* text,
+                                            int textLen,
+                                            int flags = 1,
+                                            QueryOption option = kJiebaCutWithoutHMM);
 #endif
 
- private:
-  static void append_result(std::string &result, std::string part, TokenCategory category, int offset, int flags);
+private:
+    static void append_result(std::string& result, std::string part, TokenCategory category, int offset, int flags);
 };
 
 }  // namespace simple_tokenizer
 
-extern "C" int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut);
-extern "C" int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
+extern "C" int fts5_simple_xCreate(void* sqlite3, const char** azArg, int nArg, Fts5Tokenizer** ppOut);
+extern "C" int fts5_simple_xTokenize(Fts5Tokenizer* tokenizer_ptr,
+                                     void* pCtx,
+                                     int flags,
+                                     const char* pText,
+                                     int nText,
                                      xTokenFn xToken);
-extern "C" void fts5_simple_xDelete(Fts5Tokenizer *tokenizer_ptr);
+extern "C" void fts5_simple_xDelete(Fts5Tokenizer* tokenizer_ptr);
 
-extern "C" int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);
+extern "C" int sqlite3_simple_init(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi);
 
 #endif  // SIMPLE_TOKENIZER_H_

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -7,10 +7,10 @@
 #include "cppjieba/Jieba.hpp"
 #endif
 #include "pinyin.h"
-#include "sqlite3ext.h"
 #include "simple_def.h"
+#include "sqlite3ext.h"
 
-typedef int (*xTokenFn)(void *, int, const char *, int, int, int);
+typedef int (*xTokenFn)(void*, int, const char*, int, int, int);
 
 namespace simple_tokenizer {
 
@@ -19,36 +19,59 @@ extern std::string jieba_dict_path;
 #endif
 
 enum class TokenCategory {
-  SPACE,
-  ASCII_ALPHABETIC,
-  DIGIT,
-  OTHER,
+    SPACE,
+    ASCII_ALPHABETIC,
+    DIGIT,
+    OTHER,
 };
 
 class SimpleTokenizer {
- private:
-  static PinYin *get_pinyin();
-  bool enable_pinyin = true;
+private:
+    static PinYin* get_pinyin();
+    bool enable_pinyin = true;
 
- public:
-  SimpleTokenizer(const char **zaArg, int nArg);
-  int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const;
-  static std::string tokenize_query(const char *text, int textLen, int flags = 1);
+public:
+    SimpleTokenizer(const char** zaArg, int nArg);
+    int tokenize(void* pCtx,
+                 int flags,
+                 const char* text,
+                 int textLen,
+                 xTokenFn xToken) const;
+    static std::string tokenize_query(const char* text,
+                                      int textLen,
+                                      int flags = 1);
 #ifdef USE_JIEBA
-  static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1, QueryOption option = kJiebaCutWithoutHMM);
+    static std::string tokenize_jieba_query(
+        const char* text,
+        int textLen,
+        int flags = 1,
+        QueryOption option = kJiebaCutWithoutHMM);
 #endif
 
- private:
-  static void append_result(std::string &result, std::string part, TokenCategory category, int offset, int flags);
+private:
+    static void append_result(std::string& result,
+                              std::string part,
+                              TokenCategory category,
+                              int offset,
+                              int flags);
 };
 
 }  // namespace simple_tokenizer
 
-extern "C" int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut);
-extern "C" int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
+extern "C" int fts5_simple_xCreate(void* sqlite3,
+                                   const char** azArg,
+                                   int nArg,
+                                   Fts5Tokenizer** ppOut);
+extern "C" int fts5_simple_xTokenize(Fts5Tokenizer* tokenizer_ptr,
+                                     void* pCtx,
+                                     int flags,
+                                     const char* pText,
+                                     int nText,
                                      xTokenFn xToken);
-extern "C" void fts5_simple_xDelete(Fts5Tokenizer *tokenizer_ptr);
+extern "C" void fts5_simple_xDelete(Fts5Tokenizer* tokenizer_ptr);
 
-extern "C" int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);
+extern "C" int sqlite3_simple_init(sqlite3* db,
+                                   char** pzErrMsg,
+                                   const sqlite3_api_routines* pApi);
 
 #endif  // SIMPLE_TOKENIZER_H_

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -7,10 +7,10 @@
 #include "cppjieba/Jieba.hpp"
 #endif
 #include "pinyin.h"
-#include "simple_def.h"
 #include "sqlite3ext.h"
+#include "simple_def.h"
 
-typedef int (*xTokenFn)(void*, int, const char*, int, int, int);
+typedef int (*xTokenFn)(void *, int, const char *, int, int, int);
 
 namespace simple_tokenizer {
 
@@ -19,59 +19,36 @@ extern std::string jieba_dict_path;
 #endif
 
 enum class TokenCategory {
-    SPACE,
-    ASCII_ALPHABETIC,
-    DIGIT,
-    OTHER,
+  SPACE,
+  ASCII_ALPHABETIC,
+  DIGIT,
+  OTHER,
 };
 
 class SimpleTokenizer {
-private:
-    static PinYin* get_pinyin();
-    bool enable_pinyin = true;
+ private:
+  static PinYin *get_pinyin();
+  bool enable_pinyin = true;
 
-public:
-    SimpleTokenizer(const char** zaArg, int nArg);
-    int tokenize(void* pCtx,
-                 int flags,
-                 const char* text,
-                 int textLen,
-                 xTokenFn xToken) const;
-    static std::string tokenize_query(const char* text,
-                                      int textLen,
-                                      int flags = 1);
+ public:
+  SimpleTokenizer(const char **zaArg, int nArg);
+  int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const;
+  static std::string tokenize_query(const char *text, int textLen, int flags = 1);
 #ifdef USE_JIEBA
-    static std::string tokenize_jieba_query(
-        const char* text,
-        int textLen,
-        int flags = 1,
-        QueryOption option = kJiebaCutWithoutHMM);
+  static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1, QueryOption option = kJiebaCutWithoutHMM);
 #endif
 
-private:
-    static void append_result(std::string& result,
-                              std::string part,
-                              TokenCategory category,
-                              int offset,
-                              int flags);
+ private:
+  static void append_result(std::string &result, std::string part, TokenCategory category, int offset, int flags);
 };
 
 }  // namespace simple_tokenizer
 
-extern "C" int fts5_simple_xCreate(void* sqlite3,
-                                   const char** azArg,
-                                   int nArg,
-                                   Fts5Tokenizer** ppOut);
-extern "C" int fts5_simple_xTokenize(Fts5Tokenizer* tokenizer_ptr,
-                                     void* pCtx,
-                                     int flags,
-                                     const char* pText,
-                                     int nText,
+extern "C" int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut);
+extern "C" int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
                                      xTokenFn xToken);
-extern "C" void fts5_simple_xDelete(Fts5Tokenizer* tokenizer_ptr);
+extern "C" void fts5_simple_xDelete(Fts5Tokenizer *tokenizer_ptr);
 
-extern "C" int sqlite3_simple_init(sqlite3* db,
-                                   char** pzErrMsg,
-                                   const sqlite3_api_routines* pApi);
+extern "C" int sqlite3_simple_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi);
 
 #endif  // SIMPLE_TOKENIZER_H_

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/pinyin_test.cc
+++ b/test/pinyin_test.cc
@@ -5,13 +5,14 @@
 using namespace simple_tokenizer;
 
 TEST(simple, pinyin_split) {
-  PinYin* pinyin = new PinYin();
-  auto res = pinyin->split_pinyin("a");
-  ASSERT_EQ(res.size(), 1);
-  res = pinyin->split_pinyin("ba");
-  ASSERT_EQ(res.size(), 2);
-  res = pinyin->split_pinyin("zhangliangy");
-  ASSERT_EQ(res.size(), 4);
-  for (auto r : res) std::cout << r << "\t";
-  std::cout << std::endl;
+    PinYin* pinyin = new PinYin();
+    auto res = pinyin->split_pinyin("a");
+    ASSERT_EQ(res.size(), 1);
+    res = pinyin->split_pinyin("ba");
+    ASSERT_EQ(res.size(), 2);
+    res = pinyin->split_pinyin("zhangliangy");
+    ASSERT_EQ(res.size(), 4);
+    for (auto r : res)
+        std::cout << r << "\t";
+    std::cout << std::endl;
 }

--- a/test/pinyin_test.cc
+++ b/test/pinyin_test.cc
@@ -5,14 +5,13 @@
 using namespace simple_tokenizer;
 
 TEST(simple, pinyin_split) {
-    PinYin* pinyin = new PinYin();
-    auto res = pinyin->split_pinyin("a");
-    ASSERT_EQ(res.size(), 1);
-    res = pinyin->split_pinyin("ba");
-    ASSERT_EQ(res.size(), 2);
-    res = pinyin->split_pinyin("zhangliangy");
-    ASSERT_EQ(res.size(), 4);
-    for (auto r : res)
-        std::cout << r << "\t";
-    std::cout << std::endl;
+  PinYin* pinyin = new PinYin();
+  auto res = pinyin->split_pinyin("a");
+  ASSERT_EQ(res.size(), 1);
+  res = pinyin->split_pinyin("ba");
+  ASSERT_EQ(res.size(), 2);
+  res = pinyin->split_pinyin("zhangliangy");
+  ASSERT_EQ(res.size(), 4);
+  for (auto r : res) std::cout << r << "\t";
+  std::cout << std::endl;
 }

--- a/test/tokenizer_test.cc
+++ b/test/tokenizer_test.cc
@@ -3,124 +3,103 @@
 
 using namespace simple_tokenizer;
 
-int printFn(void* pCtx,
-            int flags,
-            const char* index,
-            int len,
-            int start,
-            int end) {
-    std::cout << "\t" << index << " " << len << " " << start << " " << end
-              << "\n";
-    return 0;
+int printFn(void* pCtx, int flags, const char* index, int len, int start, int end) {
+  std::cout << "\t" << index << " " << len << " " << start << " " << end << "\n";
+  return 0;
 }
 
 TEST(simple, tokenizer_with_pinyin) {
-    SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
-    std::vector<std::string> arr;
-    std::vector<std::string> query;
-    arr.push_back("english@\"''");
-    query.push_back(
-        R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
-    arr.push_back("zhou杰伦");
-    query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰" AND "伦")VAGON");
-    arr.push_back("杰伦 zhou 123");
-    query.push_back(
-        R"VAGON("杰" AND "伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
-    for (int i = 0; i < arr.size(); i++) {
-        std::string s = arr[i];
-        std::cout << s << " as doc:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as query:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as aux:\n";
-        std::string result =
-            SimpleTokenizer::tokenize_query(s.c_str(), s.length());
-        std::cout << result << "\n";
-        ASSERT_EQ(result, query[i]);
-    }
+  SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
+  std::vector<std::string> arr;
+  std::vector<std::string> query;
+  arr.push_back("english@\"''");
+  query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
+  arr.push_back("zhou杰伦");
+  query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰" AND "伦")VAGON");
+  arr.push_back("杰伦 zhou 123");
+  query.push_back(R"VAGON("杰" AND "伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
+  for (int i = 0; i < arr.size(); i++) {
+    std::string s = arr[i];
+    std::cout << s << " as doc:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+    std::cout << s << " as query:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+    std::cout << s << " as aux:\n";
+    std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length());
+    std::cout << result << "\n";
+    ASSERT_EQ(result, query[i]);
+  }
 }
 
 TEST(simple, tokenizer_disable_pinyin) {
-    const char* p = "0";
-    SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
-    std::vector<std::string> arr;
-    std::vector<std::string> query;
-    arr.push_back("english@\"''");
-    query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
-    arr.push_back("zhou杰伦");
-    query.push_back(R"VAGON(zhou* AND "杰" AND "伦")VAGON");
-    arr.push_back("杰伦123");
-    query.push_back(R"VAGON("杰" AND "伦" AND "123"*)VAGON");
-    for (int i = 0; i < arr.size(); i++) {
-        std::string s = arr[i];
-        std::cout << s << " as doc:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as query:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as aux:\n";
-        std::string result =
-            SimpleTokenizer::tokenize_query(s.c_str(), s.length(), 0);
-        std::cout << result << "\n";
-        ASSERT_EQ(result, query[i]);
-    }
+  const char* p = "0";
+  SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
+  std::vector<std::string> arr;
+  std::vector<std::string> query;
+  arr.push_back("english@\"''");
+  query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
+  arr.push_back("zhou杰伦");
+  query.push_back(R"VAGON(zhou* AND "杰" AND "伦")VAGON");
+  arr.push_back("杰伦123");
+  query.push_back(R"VAGON("杰" AND "伦" AND "123"*)VAGON");
+  for (int i = 0; i < arr.size(); i++) {
+    std::string s = arr[i];
+    std::cout << s << " as doc:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+    std::cout << s << " as query:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+    std::cout << s << " as aux:\n";
+    std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length(), 0);
+    std::cout << result << "\n";
+    ASSERT_EQ(result, query[i]);
+  }
 }
 
 #ifdef USE_JIEBA
 TEST(simple, jieba_tokenizer_with_pinyin) {
-    SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
-    std::vector<std::string> arr;
-    std::vector<std::string> query;
-    arr.push_back("english@\"''");
-    query.push_back(
-        R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
-    arr.push_back("zhou杰伦");
-    query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰伦")VAGON");
-    arr.push_back("杰伦 zhou 123");
-    query.push_back(R"VAGON("杰伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
-    for (int i = 0; i < arr.size(); i++) {
-        std::string s = arr[i];
-        std::cout << s << " as doc:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as query:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as aux:\n";
-        std::string result =
-            SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length());
-        std::cout << result << "\n";
-        ASSERT_EQ(result, query[i]);
-    }
+  SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
+  std::vector<std::string> arr;
+  std::vector<std::string> query;
+  arr.push_back("english@\"''");
+  query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
+  arr.push_back("zhou杰伦");
+  query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰伦")VAGON");
+  arr.push_back("杰伦 zhou 123");
+  query.push_back(R"VAGON("杰伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
+  for (int i = 0; i < arr.size(); i++) {
+    std::string s = arr[i];
+    std::cout << s << " as doc:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+    std::cout << s << " as query:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+    std::cout << s << " as aux:\n";
+    std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length());
+    std::cout << result << "\n";
+    ASSERT_EQ(result, query[i]);
+  }
 }
 
 TEST(simple, jieba_tokenizer_disable_pinyin) {
-    const char* p = "0";
-    SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
-    std::vector<std::string> arr;
-    std::vector<std::string> query;
-    arr.push_back("english@\"''");
-    query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
-    arr.push_back("zhou杰伦");
-    query.push_back(R"VAGON(zhou* AND "杰伦")VAGON");
-    arr.push_back("杰伦123");
-    query.push_back(R"VAGON("杰伦" AND "123"*)VAGON");
-    for (int i = 0; i < arr.size(); i++) {
-        std::string s = arr[i];
-        std::cout << s << " as doc:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as query:\n";
-        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
-                    printFn);
-        std::cout << s << " as aux:\n";
-        std::string result =
-            SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length(), 0);
-        std::cout << result << "\n";
-        ASSERT_EQ(result, query[i]);
-    }
+  const char* p = "0";
+  SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
+  std::vector<std::string> arr;
+  std::vector<std::string> query;
+  arr.push_back("english@\"''");
+  query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
+  arr.push_back("zhou杰伦");
+  query.push_back(R"VAGON(zhou* AND "杰伦")VAGON");
+  arr.push_back("杰伦123");
+  query.push_back(R"VAGON("杰伦" AND "123"*)VAGON");
+  for (int i = 0; i < arr.size(); i++) {
+    std::string s = arr[i];
+    std::cout << s << " as doc:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+    std::cout << s << " as query:\n";
+    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+    std::cout << s << " as aux:\n";
+    std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length(), 0);
+    std::cout << result << "\n";
+    ASSERT_EQ(result, query[i]);
+  }
 }
 #endif

--- a/test/tokenizer_test.cc
+++ b/test/tokenizer_test.cc
@@ -4,102 +4,103 @@
 using namespace simple_tokenizer;
 
 int printFn(void* pCtx, int flags, const char* index, int len, int start, int end) {
-  std::cout << "\t" << index << " " << len << " " << start << " " << end << "\n";
-  return 0;
+    std::cout << "\t" << index << " " << len << " " << start << " " << end << "\n";
+    return 0;
 }
 
 TEST(simple, tokenizer_with_pinyin) {
-  SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰" AND "伦")VAGON");
-  arr.push_back("杰伦 zhou 123");
-  query.push_back(R"VAGON("杰" AND "伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length());
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰" AND "伦")VAGON");
+    arr.push_back("杰伦 zhou 123");
+    query.push_back(R"VAGON("杰" AND "伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+        std::cout << s << " as aux:\n";
+        std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length());
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 
 TEST(simple, tokenizer_disable_pinyin) {
-  const char* p = "0";
-  SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(zhou* AND "杰" AND "伦")VAGON");
-  arr.push_back("杰伦123");
-  query.push_back(R"VAGON("杰" AND "伦" AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length(), 0);
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    const char* p = "0";
+    SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(zhou* AND "杰" AND "伦")VAGON");
+    arr.push_back("杰伦123");
+    query.push_back(R"VAGON("杰" AND "伦" AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+        std::cout << s << " as aux:\n";
+        std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length(), 0);
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 
 #ifdef USE_JIEBA
 TEST(simple, jieba_tokenizer_with_pinyin) {
-  SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰伦")VAGON");
-  arr.push_back("杰伦 zhou 123");
-  query.push_back(R"VAGON("杰伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length());
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰伦")VAGON");
+    arr.push_back("杰伦 zhou 123");
+    query.push_back(R"VAGON("杰伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+        std::cout << s << " as aux:\n";
+        std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length());
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 
 TEST(simple, jieba_tokenizer_disable_pinyin) {
-  const char* p = "0";
-  SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(zhou* AND "杰伦")VAGON");
-  arr.push_back("杰伦123");
-  query.push_back(R"VAGON("杰伦" AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length(), 0);
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    const char* p = "0";
+    SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(zhou* AND "杰伦")VAGON");
+    arr.push_back("杰伦123");
+    query.push_back(R"VAGON("杰伦" AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
+        std::cout << s << " as aux:\n";
+        std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length(), 0);
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
+
 #endif

--- a/test/tokenizer_test.cc
+++ b/test/tokenizer_test.cc
@@ -3,103 +3,124 @@
 
 using namespace simple_tokenizer;
 
-int printFn(void* pCtx, int flags, const char* index, int len, int start, int end) {
-  std::cout << "\t" << index << " " << len << " " << start << " " << end << "\n";
-  return 0;
+int printFn(void* pCtx,
+            int flags,
+            const char* index,
+            int len,
+            int start,
+            int end) {
+    std::cout << "\t" << index << " " << len << " " << start << " " << end
+              << "\n";
+    return 0;
 }
 
 TEST(simple, tokenizer_with_pinyin) {
-  SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰" AND "伦")VAGON");
-  arr.push_back("杰伦 zhou 123");
-  query.push_back(R"VAGON("杰" AND "伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length());
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(
+        R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰" AND "伦")VAGON");
+    arr.push_back("杰伦 zhou 123");
+    query.push_back(
+        R"VAGON("杰" AND "伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as aux:\n";
+        std::string result =
+            SimpleTokenizer::tokenize_query(s.c_str(), s.length());
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 
 TEST(simple, tokenizer_disable_pinyin) {
-  const char* p = "0";
-  SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(zhou* AND "杰" AND "伦")VAGON");
-  arr.push_back("杰伦123");
-  query.push_back(R"VAGON("杰" AND "伦" AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_query(s.c_str(), s.length(), 0);
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    const char* p = "0";
+    SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(zhou* AND "杰" AND "伦")VAGON");
+    arr.push_back("杰伦123");
+    query.push_back(R"VAGON("杰" AND "伦" AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as aux:\n";
+        std::string result =
+            SimpleTokenizer::tokenize_query(s.c_str(), s.length(), 0);
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 
 #ifdef USE_JIEBA
 TEST(simple, jieba_tokenizer_with_pinyin) {
-  SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰伦")VAGON");
-  arr.push_back("杰伦 zhou 123");
-  query.push_back(R"VAGON("杰伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length());
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    SimpleTokenizer* t = new SimpleTokenizer(nullptr, 0);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(
+        R"VAGON(( e+n+g+l+i+s+h* OR eng+li+sh* OR english* ) AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(( z+h+o+u* OR zhou* ) AND "杰伦")VAGON");
+    arr.push_back("杰伦 zhou 123");
+    query.push_back(R"VAGON("杰伦" AND ( z+h+o+u* OR zhou* ) AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as aux:\n";
+        std::string result =
+            SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length());
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 
 TEST(simple, jieba_tokenizer_disable_pinyin) {
-  const char* p = "0";
-  SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
-  std::vector<std::string> arr;
-  std::vector<std::string> query;
-  arr.push_back("english@\"''");
-  query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
-  arr.push_back("zhou杰伦");
-  query.push_back(R"VAGON(zhou* AND "杰伦")VAGON");
-  arr.push_back("杰伦123");
-  query.push_back(R"VAGON("杰伦" AND "123"*)VAGON");
-  for (int i = 0; i < arr.size(); i++) {
-    std::string s = arr[i];
-    std::cout << s << " as doc:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(), printFn);
-    std::cout << s << " as query:\n";
-    t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(), printFn);
-    std::cout << s << " as aux:\n";
-    std::string result = SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length(), 0);
-    std::cout << result << "\n";
-    ASSERT_EQ(result, query[i]);
-  }
+    const char* p = "0";
+    SimpleTokenizer* t = new SimpleTokenizer(&p, 1);
+    std::vector<std::string> arr;
+    std::vector<std::string> query;
+    arr.push_back("english@\"''");
+    query.push_back(R"VAGON(english* AND "@" AND """" AND "'" AND "'")VAGON");
+    arr.push_back("zhou杰伦");
+    query.push_back(R"VAGON(zhou* AND "杰伦")VAGON");
+    arr.push_back("杰伦123");
+    query.push_back(R"VAGON("杰伦" AND "123"*)VAGON");
+    for (int i = 0; i < arr.size(); i++) {
+        std::string s = arr[i];
+        std::cout << s << " as doc:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_DOCUMENT, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as query:\n";
+        t->tokenize(nullptr, FTS5_TOKENIZE_QUERY, s.c_str(), s.length(),
+                    printFn);
+        std::cout << s << " as aux:\n";
+        std::string result =
+            SimpleTokenizer::tokenize_jieba_query(s.c_str(), s.length(), 0);
+        std::cout << result << "\n";
+        ASSERT_EQ(result, query[i]);
+    }
 }
 #endif


### PR DESCRIPTION
 - 处理 MSVC 编译器下无法正常编译带有中文注释的源文件
 - 增加了 query 方法通过提供不同参数来让外层决定使用何种分词逻辑
   * 0 为不分词
   * 1 为 simple 分词逻辑
   * 2 以上为 jieba 分词相关逻辑
 - 在插入数据时对 simple 的单字分词逻辑做处理，将控制字符统一按空格处理，否则可能出现将 \0 插入到 FTS 索引表导致索引表损坏问题。
 - 整理代码风格为 Chromium 80 字符风格，并整理所有文件代码结构