### PR TITLE
improve iOS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ a.out
 compile_commands.json
 libsimple.*
 build/
+build-ios/
 *.gch
 bin/
 output/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make install
 
 支持 iOS 编译：
 ```
-cmake ../.. -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../contrib/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_BITCODE=0
+./build-ios.sh
 ```
 
 ### 代码

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+
+current_dir=$(pwd)/$(dirname "$0")
+build_dir="${current_dir}/build-ios"
+lib_prefix="${current_dir}/output"
+
+cmake "$current_dir" -G Xcode -DCMAKE_TOOLCHAIN_FILE=contrib/ios.toolchain.cmake \
+ -DPLATFORM=OS64COMBINED -DENABLE_BITCODE=1 \
+ -DCMAKE_INSTALL_PREFIX="" -B "$build_dir" \
+ -DDEPLOYMENT_TARGET=8.0
+
+cd "$build_dir" || exit
+
+cmake --build "$build_dir" --config Release
+cmake --install "$build_dir" --config Release --prefix "${lib_prefix}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,12 @@ set(SOURCE_FILES
     entry.cc
 )
 
+if (IOS)
+# iOS only support static library.
+add_library(simple STATIC ${SOURCE_FILES})
+else()
 add_library(simple SHARED ${SOURCE_FILES})
+endif()
 
 if(SIMPLE_WITH_JIEBA)
   add_dependencies(simple cppjieba)
@@ -44,3 +49,9 @@ endif()
 target_link_libraries(simple PUBLIC coverage_config PRIVATE PINYIN_TEXT SQLite3)
 
 install(TARGETS simple DESTINATION bin)
+
+if (IOS)
+# iOS build as static library. so we need install PINYIN_TEXT too.
+install(TARGETS PINYIN_TEXT DESTINATION bin)
+endif()
+


### PR DESCRIPTION
iOS 编译成静态库更方便一点（编译动态库还得签名啥的。

然后静态库可以用 `sqlite3_auto_extension` 来加载项目中 simple 相关的方法 。 https://stackoverflow.com/a/2484087/6258995
```c
sqlite3_auto_extension((void (*)(void)) sqlite3_simple_init);
```

**在编译的时候，我写了一些脚本。感觉会对这个项目有用，所以就提了一个 PR。（如果不需要的话，关了就好 ^_^/**


另外在 ios 跑了一下，貌似基本问题不大。项目代码：https://github.com/MixinNetwork/flutter-plugins/pull/34 

<details>
  <summary>截图</summary>

![image](https://user-images.githubusercontent.com/17426470/145194201-96ba5ec6-3437-4937-974c-89fa97c7c301.png)

</details>



