### PR TITLE
use obj for cmrc so no need to copy PINYIN_TEXT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -400,3 +400,6 @@ jobs:
         files: ${{ github.workspace }}/../../_temp/macos/libsimple-osx-x64.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: build-iOS
+      run: ./build-ios.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(BUILD_SQLITE3)
 endif()
 
 include(contrib/CMakeRC.cmake)
-cmrc_add_resource_library(PINYIN_TEXT NAMESPACE pinyin_text contrib/pinyin.txt)
+cmrc_add_resource_library(PINYIN_TEXT TYPE OBJECT NAMESPACE pinyin_text contrib/pinyin.txt)
 # https://github.com/vector-of-bool/cmrc/issues/17#issuecomment-659501280
 set_property(TARGET PINYIN_TEXT PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ simple 是一个支持中文和拼音的 [sqlite3 fts5](https://www.sqlite.org/f
 
 
 * 下载已经编译好的插件：https://github.com/wangfenjin/simple/releases 参考 examples 目录，目前已经有 c++, python, go 和 node-sqlite3 的例子。
-* iOS 可以参考这个例子 https://github.com/wangfenjin/simple/pull/73
+* iOS 可以参考这个例子 https://github.com/wangfenjin/simple/pull/73 和 [@hxicoder](https://github.com/hxicoder) 提供的 [demo](https://github.com/hxicoder/DBDemo) .
 * 在 Rust 中使用的例子 https://github.com/wangfenjin/simple/issues/89 https://github.com/fundon/tiny-docs-se
 
 ### 命令行使用

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/sh
 
 current_dir=$(pwd)/$(dirname "$0")
 build_dir="${current_dir}/build-ios"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,9 +51,3 @@ endif()
 target_link_libraries(simple PUBLIC coverage_config PRIVATE PINYIN_TEXT SQLite3)
 
 install(TARGETS simple DESTINATION bin)
-
-if (IOS OR BUILD_STATIC)
-# iOS build as static library. so we need install PINYIN_TEXT too.
-install(TARGETS PINYIN_TEXT DESTINATION bin)
-endif()
-


### PR DESCRIPTION
@hxicoder 注意到 iOS 需要[libPINYIN_TEXT](https://github.com/hxicoder/DBDemo/blob/main/DBDemo/DBDemo/FTS/libPINYIN_TEXT.a)  这个文件，我做了点更新可以修复这个问题，这样所有东西都打包到 libsimple 里面去了。麻烦帮忙测试下这个分支

另外你也可以加一点代码展示下怎么用 jieba_query 。需要把 dict 目录也 copy 到你的库里面去。