### PR TITLE
return byte index in highlight_pos

### DIFF
--- a/examples/cpp/main.cc
+++ b/examples/cpp/main.cc
@@ -126,6 +126,18 @@ int main() {
   rc = sqlite3_exec(db, sql.c_str(), callback, 0, &zErrMsg);
   handle_rc(db, rc);
 #endif
+  // case 6: use highlight_pos
+  sql =
+      "select simple_highlight_pos(t1, 0) as matched_simple_query_special_chars from t1 where x match "
+      "simple_query('shi')";
+  rc = sqlite3_exec(db, sql.c_str(), callback, 0, &zErrMsg);
+  handle_rc(db, rc);
+  sql =
+      "select simple_highlight_pos(t1, 0) as matched_simple_query_special_chars from t1 where x match "
+      "simple_query('special')";
+  rc = sqlite3_exec(db, sql.c_str(), callback, 0, &zErrMsg);
+  handle_rc(db, rc);
+
   ms last_query = Clock::now() - before;
   std::cout << "It took " << last_query.count() << "ms for all query" << std::endl;
 


### PR DESCRIPTION
fix #109 

```shell
sqlite> .load libsimple
sqlite> CREATE VIRTUAL TABLE t1 USING fts5(x, tokenize = 'simple');
sqlite> insert into t1(x) values ('宝宝 宝贝 孩子 小孩,自拍,漫画');
sqlite> select simple_highlight_pos(t1, 0) from t1 where x match simple_query('孩');
14,17;24,27;
```