### PR TITLE
多音字拼音提取出错

### DIFF
--- a/src/pinyin.cc
+++ b/src/pinyin.cc
@@ -23,6 +23,7 @@ std::set<std::string> PinYin::to_plain(const std::string &input) {
       s.insert(value);
       s.insert(value.substr(0, 1));
       value.clear();
+      len = 1;
       continue;
     }
     len = get_str_len((unsigned char)byte);


### PR DESCRIPTION
U+7F57: luó,luō  # 罗
类似这种多音字，第一个拼音的最后一个字母带音调会导致后一个拼音提取出错