### PR TITLE
BUILD_SQLITE3为OFF时不链接SQLite3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,10 @@ else()
   target_include_directories(simple INTERFACE ${SQLITE3_HEADERS_DIR})
 endif()
 
-target_link_libraries(simple PUBLIC coverage_config PRIVATE PINYIN_TEXT SQLite3)
+if(BUILD_SQLITE3)
+  target_link_libraries(simple PUBLIC coverage_config PRIVATE PINYIN_TEXT SQLite3)
+else()
+  target_link_libraries(simple PUBLIC coverage_config PRIVATE PINYIN_TEXT)
+endif()
 
 install(TARGETS simple DESTINATION bin)


### PR DESCRIPTION
感谢大佬的分词器库。
目前我正在通过Flutter应用Simple拓展实现全文搜索，
因为Flutter这边有相关的Sqlite库，不需要自行编译和链接Sqlite库，
所以加了一个判断，避免设置BUILD_SQLITE3=OFF时编译报错。
已经在Android和iOS上通过测试了，后续或许可以提供一个Flutter移动端的例子。