### PR TITLE
修复 #158，Windows 下 Debug 版本 dll 崩溃问题

### DIFF
--- a/src/simple_tokenizer.cc
+++ b/src/simple_tokenizer.cc
@@ -21,7 +21,7 @@ PinYin *SimpleTokenizer::get_pinyin() {
   return py;
 }
 
-static TokenCategory from_char(char c) {
+static TokenCategory from_char(unsigned char c) {
   if (std::isdigit(c)) {
     return TokenCategory::DIGIT;
   }


### PR DESCRIPTION
如题，将参数类型修改为`unsigned char`，做一个隐式类型转换，即可避免`isdigit`、`isalpha`此类函数抛出断言异常。