### PR TITLE
Add support for custom pinyin dictionary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ sqlite> select simple_highlight(t1, 0, '[', ']') as text from t1 where text matc
 5. simple_snippet() 实现截取 match 片段的功能，与 sqlite 自带的 snippet 功能类似，同样是增强连续 match 的词汇分到同一组的逻辑
 6. jieba_query() 实现jieba分词的效果，在索引不变的情况下，可以实现更精准的匹配。可以通过 `-DSIMPLE_WITH_JIEBA=OFF ` 关掉结巴分词的功能 [#35](https://github.com/wangfenjin/simple/pull/35)
 7. jieba_dict() 指定 dict 的目录，只需要调用一次，需要在调用 jieba_query() 之前指定。
+8. pinyin_dict() 支持指定自定义的 `pinyin.txt` 文件路径。调用成功后会立即切换拼音映射；如果文件格式不正确，会返回错误并保持当前映射不变。
+
+### 自定义 pinyin.txt
+
+默认会使用内置在 so 中的 `contrib/pinyin.txt`。如果希望使用自己的拼音表，可以在查询前调用：
+
+```sql
+select pinyin_dict('/path/to/pinyin.txt');
+```
+
+`pinyin.txt` 每行格式与默认文件一致，例如：
+
+```text
+U+3007: líng,yuán,xīng
+U+3007: líng,yuán,xīng # 行尾注释也支持（前面需要空格）
+```
+
+注意：
+- 建议在建索引和查询前先调用一次 `pinyin_dict()`。
+- 如果替换了拼音映射，已有索引中的拼音 token 不会自动重建，需要按你的业务策略重建索引。
 
 ## 开发
 

--- a/contrib/pinyin-mini.txt
+++ b/contrib/pinyin-mini.txt
@@ -1,0 +1,3 @@
+# demo custom pinyin dictionary for example.sql
+U+5468: zhōu # 周
+U+4F26: lún  # 伦

--- a/example.sql
+++ b/example.sql
@@ -3,6 +3,19 @@
 -- load so file
 .load libsimple
 
+select '自定义拼音词典示例（只包含 周/伦 的拼音）:';
+-- 在本仓库里从 output/bin 运行本例时，路径可使用 ../../contrib/pinyin-mini.txt
+select pinyin_dict('../../contrib/pinyin-mini.txt');
+CREATE VIRTUAL TABLE t0 USING fts5(x, tokenize = 'simple');
+insert into t0(x) values ('周杰伦');
+select '    搜索 zhou，命中数量（预期 1）:', count(*) from t0 where x match simple_query('zhou');
+select '    搜索 lun，命中数量（预期 1）:', count(*) from t0 where x match simple_query('lun');
+select '    搜索 jie，命中数量（预期 0）:', count(*) from t0 where x match simple_query('jie');
+select '    搜索 zhou lun，命中数量（预期 1）:', count(*) from t0 where x match simple_query('zhou lun');
+drop table t0;
+-- 切回默认词典，保证下面示例行为不变
+select pinyin_dict('../../contrib/pinyin.txt');
+
 select '启用拼音分词：';
 -- set tokenize to simple
 CREATE VIRTUAL TABLE t1 USING fts5(x, tokenize = 'simple');

--- a/src/pinyin.h
+++ b/src/pinyin.h
@@ -106,7 +106,7 @@ class PinYin {
     };
   // clang-format on
   std::set<std::string> to_plain(const std::string &input);
-  std::map<int, std::vector<std::string> > build_pinyin_map();
+  std::map<int, std::vector<std::string> > build_pinyin_map(const std::string &pinyin_file_path);
   static int codepoint(const std::string &u);
   std::vector<std::string> _split_pinyin(const std::string &input, int begin, int end);
 
@@ -115,6 +115,7 @@ class PinYin {
   static int get_str_len(unsigned char byte);
   std::set<std::string> split_pinyin(const std::string &input);
   PinYin();
+  explicit PinYin(const std::string &pinyin_file_path);
 };
 
 }  // namespace simple_tokenizer

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -26,13 +26,14 @@ enum class TokenCategory {
 
 class SimpleTokenizer {
  private:
-  static PinYin *get_pinyin();
+  static std::shared_ptr<PinYin> get_pinyin();
   bool enable_pinyin = true;
 
  public:
   SimpleTokenizer(const char **zaArg, int nArg);
   int tokenize(void *pCtx, int flags, const char *text, int textLen, xTokenFn xToken) const;
   static std::string tokenize_query(const char *text, int textLen, int flags = 1);
+  static bool set_pinyin_dict(const std::string &pinyin_file_path, std::string &err);
 #ifdef USE_JIEBA
   static std::string tokenize_jieba_query(const char *text, int textLen, int flags = 1);
 #endif

--- a/test/pinyin_test.cc
+++ b/test/pinyin_test.cc
@@ -1,5 +1,9 @@
 #include "pinyin.h"
 
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+
 #include "gtest/gtest.h"
 
 using namespace simple_tokenizer;
@@ -14,4 +18,36 @@ TEST(simple, pinyin_split) {
   ASSERT_EQ(res.size(), 4);
   for (auto r : res) std::cout << r << "\t";
   std::cout << std::endl;
+}
+
+TEST(simple, pinyin_custom_file) {
+  std::string path = "simple_custom_pinyin_test.txt";
+  std::ofstream file(path);
+  ASSERT_TRUE(file.is_open());
+  file << "# custom pinyin file\n";
+  file << "U+6770: jié # trailing comment\n";
+  file.close();
+
+  PinYin pinyin(path);
+  auto res = pinyin.get_pinyin("杰");
+  ASSERT_EQ(res.size(), 2);
+  ASSERT_EQ(res[0], "j");
+  ASSERT_EQ(res[1], "jie");
+  std::remove(path.c_str());
+}
+
+TEST(simple, pinyin_invalid_custom_file) {
+  std::string path = "simple_invalid_pinyin_test.txt";
+  std::ofstream file(path);
+  ASSERT_TRUE(file.is_open());
+  file << "invalid line\n";
+  file.close();
+
+  EXPECT_THROW(
+      {
+        PinYin pinyin(path);
+        (void)pinyin;
+      },
+      std::runtime_error);
+  std::remove(path.c_str());
 }


### PR DESCRIPTION
- Introduce pinyin_dict() SQL function to set custom pinyin.txt
- Allow switching pinyin mapping at runtime with error handling
- Update docs and example.sql to demonstrate usage
- Add tests for custom and invalid pinyin files