### PR TITLE
Export simple_query, pinyin_dict, jieba_dict and jieba_query

### DIFF
--- a/src/entry.cc
+++ b/src/entry.cc
@@ -44,7 +44,7 @@ static int fts5_api_from_db(sqlite3 *db, fts5_api **ppApi) {
 }
 
 #ifdef USE_JIEBA
-static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {
@@ -64,7 +64,7 @@ static void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
   sqlite3_result_null(pCtx);
 }
 
-static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {
@@ -81,7 +81,7 @@ static void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) 
 }
 #endif
 
-static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {
@@ -97,7 +97,7 @@ static void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal)
   sqlite3_result_null(pCtx);
 }
 
-static void pinyin_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
+void pinyin_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal) {
   if (nVal >= 1) {
     const char *text = (const char *)sqlite3_value_text(apVal[0]);
     if (text) {

--- a/src/simple_tokenizer.h
+++ b/src/simple_tokenizer.h
@@ -44,6 +44,13 @@ class SimpleTokenizer {
 
 }  // namespace simple_tokenizer
 
+extern "C" void simple_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal);
+extern "C" void pinyin_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal);
+#ifdef USE_JIEBA
+extern "C" void jieba_dict(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal);
+extern "C" void jieba_query(sqlite3_context *pCtx, int nVal, sqlite3_value **apVal);
+#endif
+
 extern "C" int fts5_simple_xCreate(void *sqlite3, const char **azArg, int nArg, Fts5Tokenizer **ppOut);
 extern "C" int fts5_simple_xTokenize(Fts5Tokenizer *tokenizer_ptr, void *pCtx, int flags, const char *pText, int nText,
                                      xTokenFn xToken);


### PR DESCRIPTION
https://github.com/rusqlite/rusqlite/discussions/1813
https://github.com/sqlcipher/sqlcipher/issues/586

我在 rust 层重新实现了一遍 sqlite3_simple_init，发现这四个函数没导出，希望合并